### PR TITLE
docs(readme): lead with the problem, one command, and the pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-<p align="center">
-  <a href="https://tessary.ai"><img src="docs/logo/tessary-logo.png" alt="Tessary" width="88"></a>
-</p>
+<h1 align="center">
+  <img src="docs/logo/tessary-logo.png" alt="" width="48"><br>
+  Tessary
+</h1>
 
-<h1 align="center">Tessary</h1>
-
-<p align="center">Catch the agent failures that sampling misses, then find out why they happened.</p>
+<p align="center">Stop AI agents from failing silently in production.</p>
 
 <p align="center">
   <a href="./docs/index.mdx">Docs</a> ·
@@ -22,8 +21,6 @@
 Tessary is an open-source agent reliability platform for engineering teams running AI agents in production. It watches every trace an agent produces, flags the ones that look wrong with cheap classifiers, groups related findings into a case, and explains the case with an RCA (root-cause analysis) run grounded in your own repository.
 
 Agents develop production issues without crashing or returning an error. A prompt edit shifts how often a tool gets called, a model update changes what a response looks like, and nothing in the logs turns red. Most teams sample a few percent of traffic to look for this. Sampling catches the large regressions and structurally misses the small ones, and once an agent is mature, most issues are small. Tessary reads every trace instead, and keeps the per-trace check cheap enough to afford at production volume.
-
-<!-- Screenshot: a case on the Triage page with its RCA report open. Save it as docs/images/readme-case.png and replace this comment with the image. -->
 
 ## Get running
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   Tessary
 </h1>
 
-<p align="center">Stop AI agents from failing silently in production.</p>
+<p align="center">Stop your agents from failing silently in production.</p>
 
 <p align="center">
   <a href="https://tessary.ai/docs">Docs</a> ·

--- a/README.md
+++ b/README.md
@@ -24,13 +24,21 @@ Agents develop production issues without crashing or returning an error. A promp
 
 ## Get running
 
-You need Docker Engine 26 or newer and Docker Compose v2.34 or newer. Then run one command, with nothing cloned and no `.env` to edit:
+Paste this into your coding agent:
+
+```text
+Self-host Tessary for me by following https://github.com/tessaryai/tessary/blob/main/setup.md
+```
+
+[`setup.md`](./setup.md) is written as instructions to an agent: install what's missing, bring every service up, verify the frontend, and hand back the URL. It needs Docker Engine 26 or newer and Docker Compose v2.34 or newer on the machine.
+
+Prefer to run it yourself? The same install is one command, with nothing cloned and no `.env` to edit:
 
 ```bash
 docker compose -f oci://docker.io/tessaryai/tessary:compose up -d -y
 ```
 
-Open <http://localhost> when `docker compose -p tessary ps` reports every service healthy, and create the first account with an email and password. Two of the shipped credentials are placeholders published in this repository, so this install is for a localhost test drive until you replace them. [Set up Tessary](./docs/self-hosting/setup.mdx) covers that, along with a custom domain, upgrades, and troubleshooting. Handing the install to a coding agent instead? [`setup.md`](./setup.md) is written as instructions to one.
+Either way, open <http://localhost> when `docker compose -p tessary ps` reports every service healthy, and create the first account with an email and password. Two of the shipped credentials are placeholders published in this repository, so this install is for a localhost test drive until you replace them. [Set up Tessary](./docs/self-hosting/setup.mdx) covers that, along with a custom domain, upgrades, and troubleshooting.
 
 ### 1. Point your agent's traces at it
 

--- a/README.md
+++ b/README.md
@@ -1,165 +1,103 @@
-# Tessary
+<p align="center">
+  <a href="https://tessary.ai"><img src="docs/logo/tessary-logo.png" alt="Tessary" width="88"></a>
+</p>
 
-Tessary is an agent-reliability platform: it ingests every trace an agent produces, filters the ones that look bad with cheap classifiers, groups related failures into one case, and explains a case with an agentic RCA (root-cause analysis) run grounded in your own repository.
+<h1 align="center">Tessary</h1>
 
-Agents ship fast and change often, and when one degrades the team usually finds out late and still can't say why. Sampling a few percent of traces catches the big regressions; it structurally cannot catch the small ones, and once an agent is mature, every issue is a small one.
+<p align="center">Catch the agent failures that sampling misses, then find out why they happened.</p>
 
-That's why Tessary watches every trace instead of a sample. A cascade of cheap classifiers filters the potentially bad ones at production volume, similar failures group into one investigable case, and RCA explains that case against the trace evidence and your codebase, then proposes the fix as a pull request. The filter has to stay cheap enough to run unsampled: LLM work is the escalation, applied only to what the filter already flagged, never the default path.
+<p align="center">
+  <a href="./docs/index.mdx">Docs</a> ·
+  <a href="./docs/self-hosting/setup.mdx">Self-host</a> ·
+  <a href="https://github.com/tessaryai/tessary/issues">Report an issue</a>
+</p>
 
-The open edition of Tessary is open source under the [Apache License 2.0](./LICENSE); the name and logo are trademarks, see the [trademark policy](./docs/trademarks.mdx). Self-hosting is free; hosted pricing is published at [tessary.ai/#pricing](https://tessary.ai/#pricing).
+<p align="center">
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/license-Apache--2.0-blue" alt="Apache 2.0 license"></a>
+  <a href="https://github.com/tessaryai/tessary/releases"><img src="https://img.shields.io/github/v/release/tessaryai/tessary" alt="Latest release"></a>
+  <a href="https://hub.docker.com/r/tessaryai/tessary"><img src="https://img.shields.io/docker/pulls/tessaryai/tessary" alt="Docker pulls"></a>
+  <a href="https://github.com/tessaryai/tessary/actions/workflows/ci.yml"><img src="https://github.com/tessaryai/tessary/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
+</p>
 
-## Status
+Tessary is an open-source agent reliability platform for engineering teams running AI agents in production. It watches every trace an agent produces, flags the ones that look wrong with cheap classifiers, groups related findings into a case, and explains the case with an RCA (root-cause analysis) run grounded in your own repository.
 
-- OTLP (OpenTelemetry Protocol) and SDK trace ingest, on an agent-native trace substrate
-- Built-in classifiers running over live traffic
-- Cases, triage, and agentic RCA (repo-grounded, running in an E2B microVM)
-- Vitals (spend, p95 latency)
-- Alerting
-- Multi-tenant orgs, projects, RBAC (role-based access control), metering, and billing
-- An MCP (Model Context Protocol) server
+Agents develop production issues without crashing or returning an error. A prompt edit shifts how often a tool gets called, a model update changes what a response looks like, and nothing in the logs turns red. Most teams sample a few percent of traffic to look for this. Sampling catches the large regressions and structurally misses the small ones, and once an agent is mature, most issues are small. Tessary reads every trace instead, and keeps the per-trace check cheap enough to afford at production volume.
 
-See [What this does today](#what-this-does-today) for how these fit together. The hosted version at [app.tessary.ai](https://app.tessary.ai) runs this code, behind WorkOS AuthKit; a small paid overlay adds hosted-only features and isn't part of this repository.
+<!-- Screenshot: a case on the Triage page with its RCA report open. Save it as docs/images/readme-case.png and replace this comment with the image. -->
 
-This tree no longer includes graders, datasets, experiments, or a CI merge gate: an earlier evaluation half was removed outright, not deferred behind a flag. See [What this does not do (yet)](#what-this-does-not-do-yet) for what that leaves out.
+## Get running
 
-Self-hosting? The published documentation starts at [`docs/index.mdx`](./docs/index.mdx) and the walkthrough is [Set up Tessary](./docs/self-hosting/setup.mdx). Developing on the repository? Start with [the documentation map](./devdocs/README.md) and [the architecture reference](./devdocs/reference/architecture.md).
-
-## Architecture
-
-| Layer | Tech |
-|---|---|
-| Reverse proxy | Caddy 2 (TLS via Let's Encrypt, your own certificate, or a terminator you already run; see [Custom domain](docs/self-hosting/custom-domain.mdx)) |
-| Backend | Spring Boot 4.0.x, Java 25 LTS (long-term support), Maven, running on Project Loom virtual threads |
-| Frontend | React 19, Vite, TypeScript, TanStack Query, Tailwind |
-| Persistence | Postgres 16 with pgvector, migrated with Liquibase. Dev and production run the `pgvector/pgvector:pg16` container; tests use a `pgvector/pgvector:pg16` Testcontainers instance (Docker required). |
-| Auth | Email and password in the open edition (a sealed cookie session; no identity provider to configure). Tessary Cloud runs the same code behind WorkOS AuthKit. Per-project bearer tokens and API keys for MCP and headless use. See [auth and MCP reference](./devdocs/reference/auth-and-mcp.md). |
-| Telemetry | OpenTelemetry to Grafana Alloy to Grafana Cloud (traces, logs, metrics) |
-| Ingest | Direct OTLP (HTTP and gRPC) and the substrate `sdk` push source, no vendor pull |
-| Detection | Deterministic and encoder classifiers over a continuous cursor sweep of the substrate, strictly off the ingest hot path |
-| Agentic lanes | OpenCode running in an E2B microVM (RCA and Layer-2 triage), driven by the `sandbox-runner` launcher |
-
-Agent work runs out of process by design: every agentic lane gets a fresh microVM, and nothing customer-authored ever executes inside the JVM (Java virtual machine). For the full topology, see [`AGENTS.md`](./AGENTS.md) under *Architecture*, or [`devdocs/guides/local-dev.md`](./devdocs/guides/local-dev.md) for how to run it.
-
-## Quickstart
-
-Just want to self-host it, not develop on it? One command, nothing cloned, nothing to configure:
+You need Docker Engine 26 or newer and Docker Compose v2.34 or newer. Then run one command, with nothing cloned and no `.env` to edit:
 
 ```bash
 docker compose -f oci://docker.io/tessaryai/tessary:compose up -d -y
 ```
 
-That reference is the Compose configuration itself, published to Docker Hub as an artifact beside the images. Compose downloads it and runs it, so there is no clone, no `.env` and no editing before first boot. Open <http://localhost> when `docker compose -p tessary ps` reports every service healthy.
+Open <http://localhost> when `docker compose -p tessary ps` reports every service healthy, and create the first account with an email and password. Two of the shipped credentials are placeholders published in this repository, so this install is for a localhost test drive until you replace them. [Set up Tessary](./docs/self-hosting/setup.mdx) covers that, along with a custom domain, upgrades, and troubleshooting. Handing the install to a coding agent instead? [`setup.md`](./setup.md) is written as instructions to one.
 
-Every credential has a working default. Two of them are placeholders published in this repository, so a localhost test drive is all they are for: set `SITE_DOMAIN` with one still in place and the backend refuses to start rather than serving a reachable host on a key anyone can read.
+### 1. Point your agent's traces at it
 
-**[`setup.md`](./setup.md) is what to hand a coding agent.** It is written as instructions to one: install, bring every service up, verify the frontend, hand back the URL, stop. It configures nothing inside Tessary, because the product's own setup flow takes over from there. Everything past that point — creating the first account, connecting your traces, replacing the two placeholder keys, pinning a version — is [`docs/self-hosting/setup.mdx`](./docs/self-hosting/setup.mdx).
+After sign-up, Tessary shows the ingest endpoint (your origin plus `/v1/traces`) and a bearer token. Send OTLP (OpenTelemetry Protocol) traces there. Any exporter that follows the OpenTelemetry GenAI conventions works, and OpenInference and Traceloop spans normalize at the edge.
 
-**[`instrument.md`](./instrument.md) is its counterpart for the other repository** — the one whose traces you want here. Also written as instructions to an agent, but as a workflow rather than a recipe, because it runs against a repository nobody here has seen: read the repository and its own contributor instructions, propose the agent call sites it found and wait for a human to confirm them, extend whatever observability is already there instead of adding a second stack, stamp every model call's span with the `tessary.call_site.id` attribute Tessary needs to attribute a span to a call site, and finish by naming the exact files and variables the endpoint and token belong in. The connect screen's prompt is a single line pointing at it.
+Tag each span that covers a model call with the `tessary.call_site.id` attribute. It is a plain span attribute, no SDK required, and it is how Tessary attributes a span to a call site (a place in your code that invokes a model). Untagged spans arrive but don't trigger classifiers. [`instrument.md`](./instrument.md) is the workflow a coding agent follows to find your call sites, propose them for your confirmation, and add the attribute to whatever tracing you already have.
 
-The first account is an email and a password; the open edition has no sign-in provider to set up.
+Expected result: the connect screen opens on the first tagged span and drops you on **Triage**. A new project then stays quiet for a while by design, because classifiers fit a baseline per call site before they can say anything moved.
 
-From a clone, `docker compose up -d` runs the same stack from the file in this repository, and `bash scripts/quickstart.sh` does it with a readiness check instead of a fixed sleep.
+### 2. Connect the repo (optional)
 
-### What a self-hosted instance sends home, and the one switch that stops it
+Connect a GitHub repository under **Settings > Git integration**. Triage and RCA run without it, ruling on the trace evidence alone. With it, both cite the files involved, and RCA reads the code that produced the failing traces.
 
-A default install sends one anonymous heartbeat to `home.tessary.ai`, once when the backend starts and then every 24 hours. It carries a schema version and a timestamp, an install id (a random UUID minted at first boot and kept in the database), the edition, the app version, the host OS family and CPU architecture, and coarse bucketed counts of orgs, projects and daily trace volume. It never carries trace or prompt content, an email address, an org or project name, a hostname, or a retained IP address. That heartbeat is the only outbound destination a default install has.
+## How it works
+
+1. **Watch every trace.** OTLP over HTTP and gRPC, and SDK push, land in an agent-native store: a session holds traces, a trace holds spans, and each span carries its payload, tool calls, retrieved documents, and media. Everything normalizes to the OpenTelemetry `gen_ai.*` conventions at the edge. PII (personally identifiable information) redaction runs on the OTLP write path, before storage.
+2. **Filter cheaply.** Classifiers sweep the store continuously, off the ingest hot path, and create a finding when their condition is met. Two are deterministic (`secret_leak`, `malformed_output`), one profiles behavior drift by n-gram, one checks each tool's hourly failure rate, and two compare a call site's latency and cost against its own past. Model cost is paid when a classifier is fit, not per trace.
+3. **Group into cases.** Related findings collapse into one case, surfaced on **Triage**. A finding becomes a case only after an LLM triage step rules it a real deviation rather than a legitimate change.
+4. **Explain the case.** RCA runs an agentic session over the failing traces with the evidence, a dossier, and, when a repo is connected, the code itself. It returns grounded hypotheses and the checks it ruled out. Every agentic run gets a fresh E2B microVM. Nothing customer-authored executes inside the backend process.
+5. **Route it to a human.** Alerts to Slack, a webhook, Sentry, Linear, or PagerDuty carry the case to whoever owns it. Tessary explains and hands off. It doesn't open the fix.
+
+An MCP (Model Context Protocol) server exposes the same cases, traces, and RCA reports to a coding agent. See [the auth and MCP reference](./devdocs/reference/auth-and-mcp.md).
+
+## What it doesn't do yet
+
+- **The latency and cost drift classifiers are uncalibrated.** Their alert budget is a guess, and neither has fired in production. [Deviation math](./devdocs/concepts/deviation-math.md) states which numbers are measured and which are assumed.
+- **Two classifiers don't run yet.** The `frustration` and `groundedness` classifiers depend on a separate encoder service whose model weights aren't published, so the Compose configuration doesn't start it. Every other classifier runs out of the box.
+- **There is no evaluation half.** No graders, datasets, experiments, golden labels, or CI merge gate. An earlier version had them, and removing them was a decision, not a gap to fill later.
+
+## Stack
+
+| Layer | Tech |
+| --- | --- |
+| Backend | Spring Boot 4, Java 25 on virtual threads, Maven |
+| Frontend | React 19, Vite, TypeScript, TanStack Query, Tailwind |
+| Persistence | Postgres 16 with pgvector, migrated with Liquibase |
+| Reverse proxy | Caddy 2, with TLS from Let's Encrypt or your own certificate |
+| Agentic runs | OpenCode in an E2B microVM, launched by `sandbox-runner` |
+| Auth | Email and password; per-project bearer tokens and API keys for ingest and MCP |
+
+The full topology is in [the architecture reference](./devdocs/reference/architecture.md), and the standing engineering constraints are in [principles](./devdocs/reference/principles.md).
+
+## License
+
+Tessary is licensed under the [Apache License 2.0](./LICENSE). The Tessary name and logo are trademarks; see the [trademark policy](./docs/trademarks.mdx).
+
+Traces are never used to train a shared model, for any customer. Every classifier threshold is human-readable, runs on your own provider tokens, and is yours to take if you leave. [Principles](./devdocs/reference/principles.md#product--positioning) states how that guarantee is enforced.
+
+## Telemetry
+
+A self-hosted instance sends one anonymous heartbeat to `home.tessary.ai` at backend start and every 24 hours after. It carries an install id, the edition and version, the host OS family and CPU architecture, and bucketed counts of orgs, projects, and daily trace volume. It never carries trace or prompt content, an email address, an org or project name, a hostname, or an IP address. That heartbeat is the only outbound destination a default install has.
 
 ```bash
 TESSARY_TELEMETRY_ENABLED=false
 ```
 
-Set that in `.env` and the instance makes no outbound call to that host, DNS lookups included, and loses nothing: no feature, license check or in-app behaviour depends on the heartbeat reaching us. Because the install id lives in the database, a reinstall on a fresh volume counts as a new install on our side; that is the extent of what we can tell apart. The field-by-field contract is [`devdocs/reference/telemetry-contract.md`](./devdocs/reference/telemetry-contract.md), and the self-hoster's explanation is the Telemetry section of [Configuration](./docs/self-hosting/configuration.mdx).
-
-The rest of this section is the **contributor** dev loop — running the repo itself with hot reload, not the packaged self-host path above.
-
-### 1. Run the stack
-
-**Docker (recommended).** You need Docker, `tmux`, and `task` ([Task](https://taskfile.dev)).
-
-```bash
-task dev
-```
-
-This starts the dev stack in Docker (Postgres, backend, frontend, and Caddy) and opens a tmux session with 4 tabbed windows: `[0] shell` (a cheat sheet, you land here), `[1] backend`, `[2] frontend`, `[3] caddy`. The frontend has Vite HMR (hot module replacement). Rebuild the backend after a Java change with `task dev:reload-backend` from the shell window, or restart fully with `task rb`. Tear down with `task dev:stop`.
-
-Low on Docker memory, or missing HuggingFace credentials? `task dev:slim` skips the classify and compile services. Full details: [local dev guide](./devdocs/guides/local-dev.md).
-
-Open <http://localhost:8000> and create the first account with an email and password — the open edition signs up and signs in locally by default, no WorkOS or SSO configuration required (that applies to Tessary Cloud, not this repo). The account's org and default project are created for you; the connect gate that follows walks you through pointing an exporter at Tessary.
-
-For production (a Spring Boot JVM layered bootJar on a Temurin JRE, with Caddy serving the static build):
-
-```bash
-task prod:build       # fast JVM build; dependency layers cache across rebuilds
-task prod:up
-```
-
-Configuration and secrets for both paths come from environment variables; see [`.env.example`](./.env.example) for the full list.
-
-**Bare metal**, if you'd rather skip Docker. This covers the dev loop only: the three tasks below run in the foreground with no process supervision, so use the Docker path above for anything you plan to keep running.
-
-```bash
-brew install maven caddy
-curl -s "https://get.sdkman.io" | bash && source "$HOME/.sdkman/bin/sdkman-init.sh"
-sdk install java 25-tem
-
-# Node packages use pnpm. Each package.json pins the version via `packageManager`, so
-# enabling corepack once is all the setup there is; it fetches that exact version on demand.
-corepack enable
-
-task node:install     # every Node package; `task frontend:install` for just the frontend
-
-# The backend needs a Postgres 16 with pgvector reachable via TESSARY_JDBC_URL, e.g. a local
-# `pgvector/pgvector:pg16` container, or `task dev:up` to run just the compose Postgres.
-# (The backend test suite always requires Docker: it uses a pgvector Testcontainers database.)
-export TESSARY_JDBC_URL=jdbc:postgresql://localhost:5433/tessary
-export TESSARY_DB_USERNAME=tessary TESSARY_DB_PASSWORD=tessary
-
-# three terminals:
-task backend       # :8080 (connects to TESSARY_JDBC_URL)
-task frontend      # :5173
-task caddy         # :8000
-```
-
-`task check` runs the contract check, the backend `mvn verify`, frontend lint and build, and Caddyfile validation. Your local run is the gate: CI runs the same scripts, but every workflow is start-it-by-hand only ahead of the public repository cutover, so nothing runs per pull request or on a schedule. Because both run the same scripts, a green local check means CI would be green too. See [`CLAUDE.md`](./CLAUDE.md).
-
-### 2. Point your agent's traces at it
-
-Send OTLP to `/v1/traces` with a `write`-scoped API key (the connect gate mints one at sign-up; later, **Settings → Sources**). Any exporter aware of OTel-GenAI conventions works; other dialects (OpenInference, Traceloop) normalize to `gen_ai.*` at the ingest edge. Tag spans with the `tessary.call_site.id` attribute to attribute them to a call site (a place in your code that invokes a model): it's a plain span attribute, no SDK required. See the [ingestion contract reference](./devdocs/reference/ingestion-contract/README.md).
-
-Once ingest succeeds, traces begin appearing in the project. Detection itself needs history first: classifiers fit a baseline per call site before they can say anything moved, so a new project stays quiet for a while by design.
-
-### 3. Connect the repo
-
-This is an upgrade, not a setup step. Layer-2 triage runs either way: with a repo connected it rules against the committed `.tessary` bundle and cites files; without one it rules on the finding's own evidence and cites the numbers. Connecting a repo also grounds RCA in your actual code.
-
-The bundle is authored by the evals plugin for Claude Code, from [`tessaryai/plugins`](https://github.com/tessaryai/plugins) (`/plugin marketplace add tessaryai/plugins`), and imported under **Settings → Import**. A successful import shows the pipeline's call sites and failure modes on the Import page; the bundle's grader and quality-dimension shards are ignored, since this tree has nothing to run them with.
-
-## What this does today
-
-The reliability path: watch, filter, group, explain, fix.
-
-1. **Ingest everything.** Direct OTLP (HTTP and gRPC) and SDK push land in an agent-native substrate: 3 fixed levels, `session` → `trace` (one turn) → `span` (one step), each keyed on the producer's own ID, plus the span's payload, tool calls, retrieved documents, and media. Everything normalizes to the OTel `gen_ai.*` conventions at the edge, so one shape reads downstream. PII (personally identifiable information) redaction runs on the OTLP write path, before those spans are stored. It is pattern matching on one of four ingest paths; [`devdocs/concepts/pii-redaction.md`](devdocs/concepts/pii-redaction.md) § *The redaction boundary* states which paths it skips and which classes it does not catch.
-2. **Filter cheaply.** Built-in classifiers sweep the substrate continuously (a leased cursor job, strictly off the ingest hot path) and record detections: 2 are deterministic (`secret_leak`, `malformed_output`), 2 are shared ONNX (Open Neural Network Exchange) encoder heads served CPU-side by the standalone classify-service (`frustration`, `groundedness`), 1 profiles behavior drift by n-gram, and 2 watch a call site's latency and cost against its own past. Model cost is paid at train and serve time, not per event.
-3. **Group into cases.** Related findings collapse into one investigable case with a lifecycle, surfaced on **Triage**. A finding becomes a case only after an LLM triage step rules it a real deviation rather than a legitimate change.
-4. **Explain it.** RCA runs an agentic session (OpenCode in an E2B microVM) over the failing cohort with the trace evidence, a dossier, and (when a repo is connected) the code itself, and returns grounded hypotheses plus the checks it ruled out.
-5. **Route it to a human.** Alerts (Slack, webhook, Sentry, Linear, PagerDuty) carry a case to whoever owns it. The platform explains and hands off; it doesn't open the fix itself.
-
-## What this does not do (yet)
-
-- **The metric drift detectors are uncalibrated.** `duration_drift` and `cost_drift` have their alert budget still a guess, and have never fired in production. The false-alarm bar and the measured-versus-assumed split are in [deviation math](./devdocs/concepts/deviation-math.md).
-- **`tool_error` is a classifier again**, rebuilt as a rate check over each tool's hourly failure rate rather than a detection per failing call. Vitals no longer reports tool errors: one number, in one place.
-- **There is no eval half.** No grader, no judge run, no dataset, no experiment, no golden label, no review queue, and no CI merge gate. Removing them was a decision, not a gap to fill in later.
-
-## Design
-
-The product thesis and competitive frame live in Tessary's internal *Agent Reliability* document, maintained outside this repo. Standing engineering constraints are in [principles](./devdocs/reference/principles.md), and the working summary an engineer needs mid-change is in [`AGENTS.md`](./AGENTS.md) under *Strategic context*. Read those before contributing.
+Set that in `.env` and the instance makes no call to that host, DNS lookups included, and loses nothing. The field-by-field contract is [the telemetry contract](./devdocs/reference/telemetry-contract.md).
 
 ## Contributing
 
-See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for how to open a pull request or file an issue, and [`SECURITY.md`](./SECURITY.md) to report a security issue privately.
+The dev loop needs Docker, `tmux`, and [Task](https://taskfile.dev). `task dev` starts Postgres, the backend, the frontend with hot reload, and Caddy on <http://localhost:8000>, and `task check` runs the same checks as CI. [The local dev guide](./devdocs/guides/local-dev.md) covers both, including the bare-metal path, and [the documentation map](./devdocs/README.md) is where to start reading the rest.
 
-## Transparency
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) explains how to open an issue or a pull request, and what to expect from review.
 
-Every classifier's threshold is human-readable, runnable on your own provider tokens, and yours to take if you leave. The cheap filter is what makes watching every trace affordable; a classifier's false-positive rate at a stated alert budget is shown, not implied, because an unmeasured detector is a liability, not a feature.
+## Security
 
-Traces are never used to train a shared model, for any customer. See [principles](./devdocs/reference/principles.md#product--positioning) for how that guarantee is enforced.
+Report a vulnerability privately by emailing security@tessary.ai. See [`SECURITY.md`](./SECURITY.md) for what to expect.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 <p align="center">Stop AI agents from failing silently in production.</p>
 
 <p align="center">
-  <a href="./docs/index.mdx">Docs</a> ·
-  <a href="./docs/self-hosting/setup.mdx">Self-host</a> ·
+  <a href="https://tessary.ai/docs">Docs</a> ·
+  <a href="#get-running">Self-host</a> ·
   <a href="https://github.com/tessaryai/tessary/issues">Report an issue</a>
 </p>
 


### PR DESCRIPTION
## What changed

`README.md` is rewritten from 165 to 103 lines around the structure the strongest open-source READMEs share: what and why in three sentences, one command to run it, the pipeline, honest limits, then the long tail.

Section order: header (logo, tagline, link row, badges) → problem and product → Get running (one compose command, connect traces, optional repo) → How it works (5 steps) → What it doesn't do yet → Stack → License → Telemetry → Contributing → Security.

## Why

The old README opened on a status list, put the self-host command at line 43 behind an architecture table, and interleaved the contributor dev loop with the self-host path. A developer landing on the repo had to read past architecture and telemetry prose to find the run command.

The structure comes from a parallel review of 29 popular READMEs (Langfuse, PostHog, SigNoz, Sentry, Supabase, n8n, Plausible, uv, Bun, Dagger, ripgrep, and others) plus the Art of README, Standard Readme, and GitHub's own guidance. Copy follows `handbook/`: brand opening line, glossary terms, sentence-case headings, acronyms expanded on first use, no em dashes.

## For reviewers

- **Two factual corrections.** The old intro said RCA "proposes the fix as a pull request" while its pipeline section said it doesn't open the fix; nothing in the backend opens pull requests, so the new copy says Tessary explains and hands off. The old README listed `frustration` and `groundedness` as built-in classifiers; `docs/self-hosting/setup.mdx` says the Compose configuration can't run them, so they now sit under "What it doesn't do yet".
- **No hosted product is mentioned.** Tessary Cloud references were removed on request and will be added with the Cloud launch.
- **Screenshot placeholder.** An HTML comment after the intro marks where a product screenshot goes (a case on Triage with its RCA report open). None exists in the repo yet.
- **Badges.** Release, Docker pulls, and CI badges point at public endpoints and render once the repo is public. The license badge is static.
- Every relative link was checked and resolves. Removed content (bare-metal setup, tmux layout, prod build, `task check` and CI note, `.tessary` bundle detail, Design section) already lives in `devdocs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
