### PR TITLE
docs(ingest): O2 is a floor asserted in CI; the sustained capacity is a measured number

### DIFF
--- a/devdocs/guides/ingest-runbook.md
+++ b/devdocs/guides/ingest-runbook.md
@@ -15,15 +15,24 @@ which is why "is ingest healthy?" had no answer that was not a shrug.
 | # | Objective | Number | Where it comes from |
 |---|---|---|---|
 | O1 | **Accepted-write latency** — `POST /v1/traces` returns without writing to the substrate | p99 < 250 ms | in `memory` mode `enqueue` is a non-blocking hand-off; in `kafka` mode it waits for the broker's acknowledgement, bounded by `publish-timeout-ms`. The request thread never writes to Postgres, never redacts |
-| O2 | **Sustained drain rate** — spans persisted per second, single instance | ≥ 200 spans/s | the write path's stated drain budget, exercised by `SubstrateWriteIntegrationTest` against the reference Postgres; in `kafka` mode the drain runs `tessary.ingest.spool.kafka.consumers` drainers, so it scales with cores |
+| O2 | **Sustained drain rate** — spans persisted per second, single instance | ≥ 200 spans/s | a floor asserted in CI, not the measured capacity — see below for which is which. In `kafka` mode the drain runs `tessary.ingest.spool.kafka.consumers` drainers, so it scales with cores |
 | O3 | **Shed rate** — batches dropped because the queue was full | 0 over any 5-minute window under normal load | `ingest.throughput` field `shed_batches` |
 | O4 | **Spool lag** — accepted data is reaching the substrate | `spool_oldest_age_ms` under `tessary.ingest.spool.max-lag-ms` | `ingest.throughput` fields `spool_oldest_age_ms`, `queue_bytes`, `queue_max_bytes`; `oldestAgeMs` on the `/actuator/health/ingest` group (platform staff) |
 | O5 | **Write failures** — batches that exhausted their retries | 0 | `ingest.throughput` field `failed_batches` |
 | O6 | **Ingest availability** — the front door answers | ≥ 99.5% non-5xx on `/v1/traces` | `http_server_requests_seconds_count{uri="/v1/traces"}` |
 
-**Measuring these yourself.** `scripts/bench/` is an open-loop OTLP load harness and the compose
-overlay that pins a reference box; it is how the drain and redaction figures below were taken, and it
-is the way to get the same numbers for a box you actually run. It is not part of `task check`.
+**O2 is a floor, not the capacity — and the two have different sources.** The objective is a
+regression tripwire: `SubstrateWriteIntegrationTest` asserts the write path clears 200 spans/s against
+the reference Postgres, and that assertion is what keeps it honest in CI. What the path actually
+sustains is a separate number, and it is measured rather than asserted: on the self-host reference box
+(4 vCPU / 8 GiB, backend 2 vCPU) a single project sustains **~1,020 spans/s** accepted, and did ~476
+before redaction was parallelised (`tessary.redaction.parallelism`). Both figures come from
+`scripts/bench/`, which is an open-loop OTLP load harness plus the compose overlay that pins that box;
+it is not part of `task check`.
+
+Keep the two apart when you change either. Raising the objective without re-measuring turns a tripwire
+into a guess; quoting the measured ceiling as though it were the objective loses the headroom the
+tripwire exists to protect.
 
 **O2 is a single-instance number and the deployment is single-replica** (Tessary's
 hosted deployment runs one backend replica). 200 spans/s is roughly 17 million spans a day, which

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -5,9 +5,10 @@ Re-derives the ingest capacity figure in the `tessary.redaction.parallelism` ent
 measure the objectives in [`devdocs/guides/ingest-runbook.md`](../../devdocs/guides/ingest-runbook.md)
 § *The objectives* on a box you care about.
 
-Note what it does **not** claim: O2's stated provenance is `SubstrateWriteIntegrationTest`, not this
-harness. Running a ladder here gives you a second, independent number for the same objective — useful,
-and not the same thing as reproducing the one the runbook cites.
+The runbook draws the line this harness sits on: **O2 is a floor asserted by
+`SubstrateWriteIntegrationTest`; the sustained capacity is a separate, measured number, and this is
+what measures it.** Running a ladder here tells you what a box actually does. It does not, and should
+not, restate the objective.
 
 It exists because those numbers were quoted before anything here could re-derive them. A capacity
 figure with no way to re-run it is a claim, not a measurement.


### PR DESCRIPTION
## What was inconsistent

Review of #8 flagged that `ingest-runbook.md` and `scripts/bench/README.md` named two different provenances for the same number. Reading them together, the actual problem was different: **they were describing two facts as though they were one.**

- **O2 is a floor.** `SubstrateWriteIntegrationTest` asserts the write path clears 200 spans/s. That assertion is a regression tripwire and belongs in CI.
- **The sustained capacity is a measurement.** On the self-host reference box a single project sustains ~1,020 spans/s accepted (~476 before `tessary.redaction.parallelism`), from `scripts/bench/`.

The runbook carried only the first, so a reader saw "≥ 200 spans/s" with nothing to say the real ceiling is five times that. The harness README, trying not to overclaim, ended up disclaiming a conflict that only existed because the runbook was silent.

## What changed

- The objectives section states both numbers and which is which, plus the rule that keeps them apart: raising the objective without re-measuring turns a tripwire into a guess; quoting the ceiling as the objective loses the headroom the tripwire exists to protect.
- The O2 table row defers to that prose rather than restating the provenance — the fact now has one home, per `AGENTS.md`.
- The harness README stops disclaiming what it is not and says what it is.

## Notes

- Docs only. `scripts/check-docs-links.sh` passes.
- The ~1,020 figure is from the A/B in #6, re-run on the merged code at 2.29× (426 → 977 under a concurrent build). The ~476 baseline is the `parallelism=1` control.
- `SubstrateWriteIntegrationTest` still appears twice in the runbook — once here, once in the redaction-cost section, about a different measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nRCDa2UvkcjroRSzdPNAE