### PR TITLE
fix(release): answer the bind-mount prompt, verify the publish landed, and split the compose tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,14 +70,16 @@
 # on 0.2.0 with the other three services carrying no `-latest` at all; this ordering is what makes
 # that state unreachable.
 #
-# AND IT IS WHY publish-compose RUNS AFTER FINALIZE, not before it. The compose artifact NAMES
-# `<service>-<version>`, and cleanup deletes exactly those tags when a run does not commit. Publish
-# the config first and a finalize failure would leave the floating `compose` tag — the one the
-# marketing site publishes — resolving to a config whose images had just been deleted, breaking the
-# one-command install for everyone until the next release. So the config is written only once the
-# images it names are permanent, which is precisely what finalize succeeding means. cleanup's own
-# gate is the same fact read the other way: it removes version tags only when finalize did NOT
-# succeed.
+# THE TWO COMPOSE TAGS SPLIT ALONG THE SAME LINE, and this is the part that is easy to get wrong.
+# `compose-<version>` is new on every release, so it is version-scoped, deletable, and written
+# BEFORE the commit point by publish-compose — which is the whole point: if publishing does not
+# work, that is discovered while everything is still reversible, and cleanup takes the tag away
+# with the images it names. `compose` is a FLOATING ALIAS already pointing at the previous release;
+# deleting it is not a rollback, it is an outage, so it moves in finalize alongside
+# `<service>-latest` and never earlier. Publish the floating tag before the commit point and a
+# finalize failure leaves the string the marketing site publishes resolving to a config whose
+# images cleanup had just deleted — every one-command install broken until the next release, from
+# a run that never claimed to have succeeded.
 #
 # THE COMPOSE ARTIFACT (epic 7's one-command install). After the images are merged and tagged, this
 # workflow publishes docker-compose.yml itself to Docker Hub as an OCI artifact under
@@ -85,10 +87,10 @@
 #
 #   docker compose -f oci://docker.io/tessaryai/tessary:compose up -d -y
 #
-# ORDERING IS THE GUARANTEE, and it is why publish-compose `needs: finalize` rather than running
-# beside the builds: the config is published only after every image it names exists, has been proven
-# to resolve, and has been committed to, so a `compose` tag can never resolve to a config whose
-# images are not there. The reverse staleness — a config OLDER than the images — is impossible by construction,
+# ORDERING IS THE GUARANTEE, and it is why publish-compose `needs: verify-manifests` rather than
+# running beside the builds: the config is published only after every image it names exists and has
+# been proven to resolve, so a `compose` tag can never resolve to a config whose images are not
+# there. The reverse staleness — a config OLDER than the images — is impossible by construction,
 # because scripts/publish-compose-artifact.sh stamps the file's floating `${TESSARY_VERSION:-latest}`
 # defaults with THIS release's version (scripts/lib/pin-compose-version.py) before publishing it —
 # so a `compose` tag always carries a config pinned to its own release or newer, and the repository
@@ -483,11 +485,10 @@ jobs:
   publish-compose:
     name: Publish the compose artifact (the one-command install)
     runs-on: ubuntu-24.04
-    # AFTER FINALIZE, deliberately — see the header. This config names `<service>-<version>`, and
-    # those tags are only permanent once finalize has committed the release; published any earlier,
-    # a finalize failure would leave the floating `compose` tag pointing at images cleanup had just
-    # deleted.
-    needs: [preflight, merge-manifests, verify-manifests, finalize]
+    # THE PINNED TAG ONLY, and BEFORE finalize — see the header. Writing `compose-<version>` here is
+    # what proves publishing works while the run is still reversible; the floating `compose` alias
+    # is finalize's, because deleting a floating alias is an outage rather than a rollback.
+    needs: [preflight, merge-manifests, verify-manifests]
     steps:
       - uses: actions/checkout@v7
       - uses: docker/login-action@v4
@@ -495,11 +496,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Publish compose + compose-<version>
+      - name: Publish compose-<version>
         run: |
           bash scripts/publish-compose-artifact.sh \
             --repo=docker.io/${{ env.DOCKER_REPO }} \
-            --version=${{ needs.preflight.outputs.version }}
+            --version=${{ needs.preflight.outputs.version }} \
+            --tags=pinned
 
       # The published artifact has to RESOLVE and RENDER for a caller with nothing cloned. Run from
       # an empty directory so a stray repository file cannot make a broken artifact look fine.
@@ -511,7 +513,7 @@ jobs:
           # `docker.io/` spelled out, because this must exercise the EXACT string the site
           # publishes and scripts/check-compose-artifact.sh holds the docs to.
           for repo in "docker.io/${{ env.DOCKER_REPO }}"; do
-            for tag in compose "compose-${VERSION}"; do
+            for tag in "compose-${VERSION}"; do
               echo "--- oci://${repo}:${tag}"
               rendered="$(cd "$EMPTY" && docker compose -f "oci://${repo}:${tag}" config)"
               for service in backend frontend sandbox-runner; do
@@ -531,13 +533,14 @@ jobs:
   # cleanup job (deleting a moved alias is worse than the move; a pushed tag makes the version
   # unreleasable again), so both wait until every image exists, resolves and carries both arches.
   #
-  # Reaching this job green is what MAKES `<service>-<version>` permanent, and everything that
-  # depends on those tags staying put — publish-compose above all — is downstream of it for that
-  # reason. See the header.
+  # THREE aliases move here, not two: `<service>-latest` for each of the four images AND the
+  # floating `compose` tag, which is the string the marketing site publishes. All of them already
+  # point at the previous release, so none can be rolled back by deletion — which is exactly the
+  # property that decides what belongs in this job. See the header.
   finalize:
-    name: Repoint -latest and push the release tag
+    name: Repoint -latest and compose, push the release tag
     runs-on: ubuntu-24.04
-    needs: [preflight, merge-manifests, verify-manifests]
+    needs: [preflight, merge-manifests, verify-manifests, publish-compose]
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-buildx-action@v4
@@ -559,6 +562,29 @@ jobs:
               "${{ env.DOCKER_REPO }}:${service}-${VERSION}"
           done
 
+      # The floating alias, now that `-latest` resolves to this release. publish-compose already
+      # wrote `compose-<version>` from the identical file and proved it renders, so this cannot be
+      # the first time the publish path is exercised.
+      - name: Repoint the floating compose tag
+        run: |
+          bash scripts/publish-compose-artifact.sh \
+            --repo=docker.io/${{ env.DOCKER_REPO }} \
+            --version=${{ needs.preflight.outputs.version }} \
+            --tags=floating
+
+      - name: Verify oci://...:compose renders and pins this release
+        run: |
+          set -euo pipefail
+          VERSION="${{ needs.preflight.outputs.version }}"
+          REF="oci://docker.io/${{ env.DOCKER_REPO }}:compose"
+          EMPTY="$(mktemp -d)"
+          rendered="$(cd "$EMPTY" && docker compose -f "$REF" config)"
+          for service in backend frontend sandbox-runner agent-sandbox; do
+            printf '%s\n' "$rendered" | grep -qF "tessaryai/tessary:${service}-${VERSION}" || {
+              echo "::error::${REF} does not pin ${service} to ${VERSION}" >&2; exit 1; }
+          done
+          echo "OK: ${REF} renders and pins ${VERSION}"
+
       - name: Create and push the release tag
         run: |
           set -euo pipefail
@@ -574,9 +600,9 @@ jobs:
   github-release:
     name: Publish the GitHub Release
     runs-on: ubuntu-24.04
-    # The Release announces the install command, so it waits on the artifact that command fetches —
-    # publish-compose, which in turn waits on finalize, so the tag this names is already pushed.
-    needs: [preflight, publish-compose]
+    # finalize is what pushes the tag this names and what points the install command's `compose`
+    # tag at this release, so there is nothing left to announce until it is green.
+    needs: [preflight, finalize]
     steps:
       # NO CHECKOUT. `gh release create` works over the API against --repo, the tag it names is
       # already on the remote (finalize pushed it), and --generate-notes builds the changelog
@@ -610,9 +636,11 @@ jobs:
   #                           release on a PUBLIC repository, where `backend-<version>-amd64` reads
   #                           like a legitimate thing to pull and hands whoever pulls it an image
   #                           that will not run on their machine.
-  #   finalize did not    ->  the four `<service>-<version>` manifests go too, so a half-finished
-  #                           release leaves no version tag behind and the same version can be
-  #                           dispatched again cleanly.
+  #   finalize did not    ->  the four `<service>-<version>` manifests AND `compose-<version>` go
+  #                           too, so a half-finished release leaves nothing version-scoped behind
+  #                           and the same version can be dispatched again cleanly. The floating
+  #                           `compose` and `<service>-latest` are untouched because finalize is
+  #                           the only job that writes them and it did not run.
   #
   # THE GATE IS FINALIZE, NOT THE RUN'S OVERALL RESULT, and the difference is load-bearing. Once
   # finalize is green the release is committed: `<service>-latest` points at those manifests and
@@ -673,8 +701,9 @@ jobs:
             echo "  github-release: ${RELEASE_RESULT}"
           else
             echo "finalize did not succeed (${FINALIZE_RESULT}); nothing downstream can be holding a"
-            echo "reference, so this run's version tags go with the scratch ones."
+            echo "reference, so this run's version-scoped tags go with the scratch ones."
             for service in $SERVICES; do tags+=("${service}-${VERSION}"); done
+            tags+=("compose-${VERSION}")
           fi
 
           # jq builds the body so neither credential is ever spliced into JSON by the shell.

--- a/scripts/publish-compose-artifact.sh
+++ b/scripts/publish-compose-artifact.sh
@@ -57,10 +57,19 @@ VERSION="$(git -C "$ROOT" tag --list 'v[0-9]*' --sort=-v:refname 2>/dev/null | h
 VERSION="${VERSION#v}"
 REPOS=()
 DRY_RUN=0
+# WHICH OF THE TWO TAGS TO WRITE. They are not interchangeable: `compose-<version>` is new on every
+# release and can be deleted again, while `compose` is a FLOATING ALIAS that already points at the
+# previous release and cannot be rolled back by deleting it. release.yml therefore writes the
+# pinned one before it commits (so a publish that does not work fails while everything is still
+# reversible) and the floating one only in finalize, alongside `<service>-latest`. `both` stays the
+# default so a human running this by hand against an already-tagged release gets both.
+TAGS=both
 for arg in "$@"; do
     case "$arg" in
         --repo=*) REPOS+=("${arg#--repo=}") ;;
         --version=*) VERSION="${arg#--version=}" ;;
+        --tags=pinned|--tags=floating|--tags=both) TAGS="${arg#--tags=}" ;;
+        --tags=*) echo "$P: --tags takes pinned, floating or both" >&2; exit 2 ;;
         --dry-run) DRY_RUN=1 ;;
         *) echo "$P: unknown argument '$arg'" >&2; exit 2 ;;
     esac
@@ -90,9 +99,14 @@ python3 "$ROOT/scripts/lib/strip-compose-build.py" docker-compose.yml "$STRIPPED
 python3 "$ROOT/scripts/lib/pin-compose-version.py" "$STRIPPED" "$PINNED" "$VERSION"
 mv "$PINNED" "$STRIPPED"
 
+case "$TAGS" in
+    pinned)   WANT=("compose-${VERSION}") ;;
+    floating) WANT=("compose") ;;
+    both)     WANT=("compose" "compose-${VERSION}") ;;
+esac
 REFS=()
 for repo in "${REPOS[@]}"; do
-    for tag in "compose" "compose-${VERSION}"; do
+    for tag in "${WANT[@]}"; do
         REFS+=("${repo}:${tag}")
     done
 done
@@ -124,8 +138,27 @@ for ref in "${REFS[@]}"; do
         continue
     fi
     echo "$P: publishing $ref"
-    docker compose -f "$STRIPPED" publish -y "$ref"
+    # `yes |` IS LOAD-BEARING, and `-y` alone is not enough. `-y` answers the variables prompt;
+    # the file also declares a bind mount (the docker socket, which check-compose-artifact.sh
+    # allows by name) and THAT prompt is separate. On a runner it reads EOF, defaults to No, and
+    # `docker compose publish` then EXITS 0 HAVING WRITTEN NOTHING — which is how run
+    # 34336599569 printed "published" for two tags that were never created. Same TTY-gated trap
+    # as the `-y` on the `up` command in check-compose-artifact.sh's own note.
+    yes | docker compose -f "$STRIPPED" publish -y "$ref"
 done
 
 [ "$DRY_RUN" = 1 ] && exit 0
-echo "$P: published compose + compose-${VERSION} to: ${REPOS[*]}"
+
+# PUBLISHING IS NOT BELIEVED, IT IS CHECKED. The exit code above has already been observed to be 0
+# for a publish that silently did nothing, so the only trustworthy evidence is the registry saying
+# the tag is there and is a compose artifact.
+for ref in "${REFS[@]}"; do
+    if raw=$(docker buildx imagetools inspect "$ref" --raw 2>/dev/null) \
+       && printf '%s' "$raw" | grep -q 'application/vnd.docker.compose.file+yaml'; then
+        echo "$P: ok       $ref is published and is a compose artifact"
+    else
+        echo "$P: FAILED — $ref did not publish; the registry does not hold a compose artifact there." >&2
+        exit 1
+    fi
+done
+echo "$P: published ${WANT[*]} to: ${REPOS[*]}"


### PR DESCRIPTION
Run [34336599569](https://github.com/tessaryai/tessary/actions/runs/34336599569) published every image correctly and then failed, leaving `v0.3.0`, four repointed `-latest` aliases, **no compose artifact and no GitHub Release.** Two distinct faults.

## 1. The publish silently did nothing

```
publish-compose-artifact: publishing docker.io/tessaryai/tessary:compose
Are you ok to publish these bind mount declarations? [y/N]: publish-compose-artifact: publishing ...compose-0.3.0
Are you ok to publish these bind mount declarations? [y/N]: publish-compose-artifact: published compose + compose-0.3.0
```

`docker compose publish -y` answers the *variables* prompt but not the separate confirmation for the file's bind mount — the docker socket, which `check-compose-artifact.sh` allows by name. On a runner that prompt reads EOF, defaults to **No**, and the command **exits 0 having written nothing**. So the script cheerfully reported publishing two tags that were never created, and only the workflow's own render check caught it.

This is the same TTY-gated trap `check-compose-artifact.sh` already documents for the `-y` on `up`.

Two fixes: `yes |` feeds the prompt, and the script no longer treats the exit code as evidence — it asks the registry whether each ref is actually there and actually is a compose artifact, and fails loudly if not.

## 2. The commit point was in the wrong place — my error

The previous PR moved `publish-compose` *after* `finalize` so `cleanup` could never orphan the compose artifact. That protected the artifact and broke something worse: `finalize` moved `-latest` and pushed `v0.3.0` **before** the artifact those aliases advertise was known to work. A compose failure now commits a release that has no install — which is exactly the state this run left behind, and exactly what you flagged.

The mistake was treating the two compose tags as one thing. They sit on opposite sides of the line:

| tag | nature | written |
|---|---|---|
| `compose-<version>` | version-scoped, new every release, **deletable** | `publish-compose`, before the commit point |
| `compose` | floating alias already pointing at the previous release; deleting it is an outage, not a rollback | `finalize`, beside `<service>-latest` |

Writing the pinned tag early is what proves the publish path works while everything is still reversible. `finalize` then moves the floating alias and verifies it renders before pushing the tag. `cleanup` takes `compose-<version>` back along with the version manifests when `finalize` does not commit.

```
merge-manifests → verify-manifests → publish-compose (compose-<version>)
  → finalize (-latest ×4, compose, git tag) → github-release → cleanup
```

`publish-compose-artifact.sh` grows `--tags=pinned|floating|both`, with `both` still the default for a human running it by hand.

## What the run did prove

Everything up to compose worked, including the parts added in #12 and #14:

- 8 native builds green; backend 48s amd64 / 71s arm64 on a warm cache, down from 351s/284s cold
- both arches' content checks green
- `merge-manifests` and `verify-manifests` green — all four resolve, both platforms
- `finalize` repointed all four `-latest` and pushed `v0.3.0`
- **`cleanup` behaved exactly as designed**: `finalize` was green, so it deleted the 8 scratch tags and left every version tag alone. Docker Hub has no `-<arch>` tags at all now.

## State to clean up by hand before re-dispatching

`0.3.0` is spent — `v0.3.0` exists, so preflight will refuse it. Next dispatch needs a new version.

Left on Docker Hub from that run: `{backend,frontend,sandbox-runner,agent-sandbox}-0.3.0` and their four `-latest` aliases, all valid and multi-arch. Also the older `-alpha` set from a much earlier rehearsal. Nothing is broken — there is simply no `compose` tag and no Release for 0.3.0.

## Verification

- `bash -n` clean; `--dry-run` exercised for `--tags=pinned` and `--tags=floating`.
- YAML parses; `needs` graph as above.
- `check-compose-artifact.sh`, `check-required-inputs.sh`, `check-version-consistency.sh` green.

**Not executed.** The `yes |` fix in particular can only be proven by a real dispatch — it is invisible to every local check, for the same reason the bug was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
