### PR TITLE
feat(release): say in the dropdown which number each bump moves

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,9 +156,12 @@ name: Release
 #       bump:
 #         description: "Which part of the newest release tag to bump"
 #         required: true
-#         default: patch
+#         default: "Patch (x.y.z+1)"
 #         type: choice
-#         options: [patch, minor, major]
+#         options:
+#           - "Patch (x.y.z+1)"
+#           - "Minor (x.y+1.0)"
+#           - "Major (x+1.0.0)"
 
 on:
   workflow_dispatch:
@@ -166,9 +169,16 @@ on:
       bump:
         description: "Which part of the newest release tag to bump"
         required: true
-        default: patch
+        default: "Patch (x.y.z+1)"
         type: choice
-        options: [patch, minor, major]
+        # Each option carries the worked example of what it does to x.y.z, because the dropdown is
+        # the last thing a human sees before a release and GitHub cannot interpolate the real base
+        # tag into it. Placeholders rather than today's numbers: a literal here would be a copy of
+        # the version, and the copy is what goes stale.
+        options:
+          - "Patch (x.y.z+1)"
+          - "Minor (x.y+1.0)"
+          - "Major (x+1.0.0)"
 
 # ONE RELEASE AT A TIME. Two dispatches in flight would interleave their `imagetools create` calls
 # and could leave `<service>-latest` pointing at the older of the two. `cancel-in-progress: false`
@@ -225,6 +235,11 @@ jobs:
             exit 1
           fi
           IFS=. read -r MAJOR MINOR PATCH <<<"${BASE#v}"
+          # The dropdown labels carry their own worked example, so the value arrives as
+          # `Patch (x.y.z+1)`. The first word is the bump, lowercased; the rest was for the human.
+          # `tr` rather than bash 4's `${BUMP,,}`, which is a syntax error on the bash 3.2 a macOS
+          # contributor would test this logic with.
+          BUMP="$(printf '%s' "${BUMP%% *}" | tr '[:upper:]' '[:lower:]')"
           case "$BUMP" in
             major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
             minor) MINOR=$((MINOR + 1)); PATCH=0 ;;


### PR DESCRIPTION
Follow-up to #19, which replaced the typed version with a `patch` / `minor` / `major` dropdown. The labels named the part but not the effect, and the effect people get wrong is that everything to the right of the bumped position resets to zero.

## What changed

```yaml
        default: "Patch (x.y.z+1)"
        type: choice
        options:
          - "Patch (x.y.z+1)"
          - "Minor (x.y+1.0)"
          - "Major (x+1.0.0)"
```

The label is also the value GitHub hands the job, so preflight takes the first word and lowercases it before the `case`:

```bash
BUMP="$(printf '%s' "${BUMP%% *}" | tr '[:upper:]' '[:lower:]')"
```

`tr` rather than bash 4's `${BUMP,,}`: the runner has bash 5, but `${BUMP,,}` is a syntax error on the bash 3.2 that ships with macOS, so anyone extracting this logic to test it locally would hit it. Confirmed the hard way while testing this change.

Everything downstream is untouched. The `case` arms and the error message stay lowercase, so the summary still reads `v0.3.0 -> v0.3.1 (patch bump, revision …)`.

## Why placeholders and not the real numbers

`Patch (0.3.0 -> 0.3.1)` would be more immediately readable and is not possible: GitHub renders the dispatch form from the workflow file on the selected ref **before any runner exists**, so no expression in `on:` can read the newest tag. (`run-name:` has the same limit; it sees only the `github` and `inputs` contexts.)

It is also not desirable. A real number in the options is a copy of the version living in the tree, which is exactly what this workflow's design removes, and `check-version-consistency.sh` would not catch it, since its pattern requires a `tessaryai/tessary:` prefix. It would rot silently. Keeping the dropdown static and letting preflight state the real resolution in the step summary keeps the tag the only source of truth.

## Testing

The preflight body was extracted and run against a scratch repo tagged `v0.3.0`:

| Dispatched label | Result |
|---|---|
| `Patch (x.y.z+1)` | `version=0.3.1`, summary `v0.3.0 -> v0.3.1 (patch bump, …)` |
| `Minor (x.y+1.0)` | `version=0.4.0` |
| `Major (x+1.0.0)` | `version=1.0.0` |
| `Sideways (x)` | refused, `Unknown bump 'sideways'` |

The workflow parses as YAML and the `default` string matches an option exactly, which GitHub requires or the dispatch form breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
