### PR TITLE
fix(traces): let the table fill a wide screen instead of stopping at the column sum

### DIFF
--- a/frontend/src/views/traces/TracesIndex.tsx
+++ b/frontend/src/views/traces/TracesIndex.tsx
@@ -31,6 +31,7 @@ import {
   COLUMN_DEFS,
   ColumnsControl,
   SESSION_EXPAND_COLUMN_WIDTH,
+  columnWidths,
   useColumnConfig,
   type ColumnDef,
   type ColumnKey,
@@ -130,10 +131,13 @@ export function TracesIndex() {
     else next.delete("groupBy");
     setSearchParams(next);
   };
-  const tableWidth = Math.max(
+  // The floor the table never goes below — below it the wrapper scrolls rather than the columns
+  // shrinking. Above it the table fills the page and `columnWidths` decides where the surplus goes.
+  const tableMinWidth = Math.max(
     760,
     columns.reduce((sum, c) => sum + c.width, 0) + (groupBySession ? SESSION_EXPAND_COLUMN_WIDTH : 0),
   );
+  const colWidths = columnWidths(columns, groupBySession ? SESSION_EXPAND_COLUMN_WIDTH : 0);
 
   // Filtering happens server-side — the list is keyset-paginated, so narrowing
   // it in the browser would only ever filter the page that happens to be loaded.
@@ -358,10 +362,12 @@ export function TracesIndex() {
         // depend on what's currently in it. Under auto layout, Input/Output swinging between a long
         // preview (trace rows) and a bare "—" (session rollup rows) resized the whole table on every
         // flat/grouped toggle and every session expand/collapse — see COLUMN_DEFS's width doc comment.
-        <Table className="text-body" style={{ tableLayout: "fixed", width: tableWidth, minWidth: tableWidth }}>
+        // The table itself stays `w-full` (from Table) so a monitor wider than the column sum is
+        // used rather than left blank; `columnWidths` hands that surplus to the text columns.
+        <Table className="text-body" style={{ tableLayout: "fixed", minWidth: tableMinWidth }}>
           <colgroup>
-            {columns.map((col) => (
-              <col key={col.key} style={{ width: col.width }} />
+            {columns.map((col, i) => (
+              <col key={col.key} style={{ width: colWidths[i] }} />
             ))}
             {groupBySession && <col style={{ width: SESSION_EXPAND_COLUMN_WIDTH }} />}
           </colgroup>

--- a/frontend/src/views/traces/columnWidths.test.ts
+++ b/frontend/src/views/traces/columnWidths.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it } from "vitest";
+import { COLUMN_DEFS, SESSION_EXPAND_COLUMN_WIDTH, columnWidths, type ColumnDef } from "./index-columns";
+
+const byKey = (...keys: string[]): ColumnDef[] =>
+  keys.map((k) => {
+    const col = COLUMN_DEFS.find((c) => c.key === k);
+    if (!col) throw new Error(`no column ${k}`);
+    return col;
+  });
+
+describe("columnWidths", () => {
+  it("leaves a non-flex column at its declared pixel width", () => {
+    const [when, latency] = columnWidths(byKey("when", "latency"));
+    expect(when).toBe(150);
+    expect(latency).toBe(140);
+  });
+
+  it("subtracts every fixed column from the flex columns' share", () => {
+    // when 150 + latency 140 fixed; name 260 + input 280 + output 280 = 820 flexible.
+    const widths = columnWidths(byKey("when", "name", "input", "output", "latency"));
+    expect(widths[0]).toBe(150);
+    expect(widths[4]).toBe(140);
+    expect(widths[1]).toBe(`calc((100% - 290px) * ${(260 / 820).toFixed(6)})`);
+    expect(widths[2]).toBe(`calc((100% - 290px) * ${(280 / 820).toFixed(6)})`);
+    expect(widths[3]).toBe(widths[2]);
+  });
+
+  it("counts the pinned expand column as fixed width", () => {
+    const widths = columnWidths(byKey("when", "name"), SESSION_EXPAND_COLUMN_WIDTH);
+    expect(widths[1]).toBe("calc((100% - 190px) * 1.000000)");
+  });
+
+  it("hands the flex columns the whole surplus", () => {
+    // The shares sum to 1, so at any table width the flex columns take exactly what the fixed
+    // columns leave — no surplus stranded, none double-counted.
+    const cols = byKey("when", "name", "input", "output", "latency", "cost", "tokens", "spans");
+    const shares = columnWidths(cols)
+      .filter((w): w is string => typeof w === "string")
+      .map((w) => Number(/\* ([\d.]+)\)$/.exec(w)?.[1]));
+    expect(shares).toHaveLength(3);
+    expect(shares.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 4);
+  });
+
+  it("falls back to declared widths when no flex column is visible", () => {
+    expect(columnWidths(byKey("when", "latency", "cost"))).toEqual([150, 140, 90]);
+  });
+});

--- a/frontend/src/views/traces/index-columns.tsx
+++ b/frontend/src/views/traces/index-columns.tsx
@@ -50,7 +50,7 @@ export type ColumnKey =
   | "session"
   | "sessionExpand";
 
-export type ColumnDef = { key: ColumnKey; label: string; numeric?: boolean; width: number };
+export type ColumnDef = { key: ColumnKey; label: string; numeric?: boolean; flex?: boolean; width: number };
 
 /**
  * Declaration order is display order — the table renders whichever of these are visible, in this
@@ -60,12 +60,14 @@ export type ColumnDef = { key: ColumnKey; label: string; numeric?: boolean; widt
  * scanning every cell's content — which meant Input/Output (long text preview vs. a bare "—" on a
  * session rollup row) would visibly resize the whole table on every toggle between flat and
  * grouped-by-session, and again on every session expand/collapse. Fixed widths make both silent.
+ *
+ * `flex` marks the columns whose width is a floor rather than a fixed size — see `columnWidths`.
  */
 export const COLUMN_DEFS: ColumnDef[] = [
   { key: "when", label: "Start time", width: 150 },
-  { key: "name", label: "Name", width: 260 },
-  { key: "input", label: "Input", width: 280 },
-  { key: "output", label: "Output", width: 280 },
+  { key: "name", label: "Name", flex: true, width: 260 },
+  { key: "input", label: "Input", flex: true, width: 280 },
+  { key: "output", label: "Output", flex: true, width: 280 },
   // Wide enough for the longest tier ("3d 2h 15m 30s") without truncating under table-layout: fixed.
   { key: "latency", label: "Latency", numeric: true, width: 140 },
   { key: "cost", label: "Cost ($)", numeric: true, width: 90 },
@@ -84,6 +86,29 @@ export const COLUMN_DEFS: ColumnDef[] = [
   { key: "traceId", label: "Trace ID", width: 200 },
   { key: "session", label: "Session ID", width: 200 },
 ];
+
+/**
+ * The `<colgroup>` widths, as CSS width values, for the visible columns in display order.
+ *
+ * The table is `width: 100%` with the column sum as its `min-width`: narrower than the sum it
+ * scrolls at exactly these widths, wider than the sum the surplus has to go somewhere. Left to the
+ * browser the surplus is spread across every column, which pads the numeric ones that were already
+ * sized to their longest value and leaves the text previews truncating anyway. So it goes to the
+ * `flex` columns instead, split in proportion to their declared widths — on a wide monitor the
+ * table fills the page and Input/Output show more of the payload, which is the point of them.
+ *
+ * `extraFixedPx` is width the table carries outside `columns` (the pinned expand column in grouped
+ * mode). With no flex column visible there is nothing to hand the surplus to, so the declared
+ * widths are returned as-is and the browser's own distribution is left alone.
+ */
+export function columnWidths(columns: ColumnDef[], extraFixedPx = 0): (string | number)[] {
+  const flexTotal = columns.reduce((sum, c) => (c.flex ? sum + c.width : sum), 0);
+  if (flexTotal === 0) return columns.map((c) => c.width);
+  const fixedPx = columns.reduce((sum, c) => (c.flex ? sum : sum + c.width), extraFixedPx);
+  return columns.map((c) =>
+    c.flex ? `calc((100% - ${fixedPx}px) * ${(c.width / flexTotal).toFixed(6)})` : c.width,
+  );
+}
 
 /** The pinned expand-chevron column's width, in grouped mode — shared with its TD/TH styling below. */
 export const SESSION_EXPAND_COLUMN_WIDTH = 40;


### PR DESCRIPTION
## What

The traces table set both `width` and `min-width` to the sum of its visible `<colgroup>` pixel widths, so it could neither shrink (intended — the wrapper scrolls) nor grow. On a monitor wider than that sum it stopped around 1400px and left the rest of the page blank, while Input and Output went on truncating.

The sum is now only the `min-width`. The table keeps the `w-full` it gets from the `Table` primitive, so it fills its container, and a new `columnWidths()` decides where the surplus goes.

## How

`ColumnDef` gains a `flex` flag, set on Name, Input and Output. `columnWidths(columns, extraFixedPx)` returns the `<colgroup>` widths:

- fixed columns keep their declared pixels;
- flex columns get `calc((100% - <fixedPx>px) * <share>)`, split in proportion to their declared widths.

Left to the browser, the surplus is spread across every column — which pads the numeric ones that were already sized to their longest value, and leaves the text previews truncating anyway. This hands it to the columns that actually run out of room.

Below the sum nothing changes: the percentages resolve back to exactly 260/280/280 and the wrapper scrolls as before. `extraFixedPx` covers the pinned expand column in grouped-by-session mode. With no flex column visible the declared widths are returned as-is and the browser's own distribution is left alone.

## Notes for review

- **No other table is affected.** Vitals, Evidence, Organization and Classifiers set `min-width` only (or nothing) on top of the primitive's `w-full`, so they already filled the page. Traces was the only `<Table>` setting an explicit `width`.
- **`table-layout: fixed` is unchanged**, and so is the reason for it — a column's width still never depends on what is currently in it, so the flat/grouped toggle and session expand/collapse stay silent.
- **Verification.** `pnpm test` (85 pass, 5 new for `columnWidths`), `tsc --noEmit` clean, `scripts/check-frontend.sh` clean. I did *not* verify in a running app: the local `.claude/launch.json` points at a `vite.config.preview.ts` that does not exist in the tree, and the table needs the backend for rows. The layout itself rests on percentage `<col>` widths resolving against the table's used width under fixed layout, which is worth an eye on a wide monitor before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)