### PR TITLE
fix(sandbox-runner): use OpenAI's own SDK for OpenAI runs, and bump opencode to 1.18.30

### DIFF
--- a/sandbox-runner/agent-sandbox/Dockerfile
+++ b/sandbox-runner/agent-sandbox/Dockerfile
@@ -49,7 +49,7 @@
 #      has NO apkInstall, so template.ts's mirror of this line has to be a raw `.runCmd`.
 #
 # The musl swap itself is verified, not assumed: re2@1.26.1 compiles under Alpine's g++ and matches
-# correctly, opencode-ai 1.18.13 installs and runs, PyYAML imports, and @opencode-ai/sdk loads.
+# correctly, opencode-ai 1.18.30 installs and runs, PyYAML imports, and @opencode-ai/sdk loads.
 FROM node:22-alpine3.24
 
 # The `tar` module npm vendors (usr/local/lib/node_modules/npm/node_modules/tar) ships at 7.5.11 on
@@ -99,7 +99,7 @@ RUN python3 -m pip install --no-cache-dir --break-system-packages pyyaml
 # `set -e` plus the empty-inode guard matter: if stat ever fails, this must abort the build rather
 # than fall through to a loop that deletes every variant including the live one.
 RUN set -e; \
-    npm install -g opencode-ai@1.18.13; \
+    npm install -g opencode-ai@1.18.30; \
     D=/usr/local/lib/node_modules/opencode-ai; \
     INO="$(stat -c %i "$D/bin/opencode.exe")"; \
     [ -n "$INO" ] || { echo "could not stat opencode.exe" >&2; exit 1; }; \
@@ -138,7 +138,7 @@ WORKDIR /home/user
 # is already in the base image). undici pins to ^6 so this line stays byte-identical to
 # template.ts's (bump every recipe together; undici 8 needs node >=22.19, fine on node:22-alpine3.24).
 # The cache clean is size only: npm leaves ~38 MB in $HOME/.npm that nothing at runtime reads.
-RUN npm install acorn@^8.18.0 acorn-walk@^8.3.5 re2@^1.26.1 @opencode-ai/sdk@1.18.13 undici@^6.28.0 \
+RUN npm install acorn@^8.18.0 acorn-walk@^8.3.5 re2@^1.26.1 @opencode-ai/sdk@1.18.30 undici@^6.28.0 \
     && npm cache clean --force
 
 # The bundle contract, copied straight from its repo-root source of truth (contract/) rather than

--- a/sandbox-runner/agent-sandbox/package.json
+++ b/sandbox-runner/agent-sandbox/package.json
@@ -9,7 +9,7 @@
   },
   "packageManager": "pnpm@11.15.1",
   "dependencies": {
-    "@opencode-ai/sdk": "1.18.13",
+    "@opencode-ai/sdk": "1.18.30",
     "acorn": "^8.18.0",
     "acorn-walk": "^8.3.5",
     "e2b": "^2.46.1",

--- a/sandbox-runner/agent-sandbox/pnpm-lock.yaml
+++ b/sandbox-runner/agent-sandbox/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@opencode-ai/sdk':
-        specifier: 1.18.13
-        version: 1.18.13
+        specifier: 1.18.30
+        version: 1.18.30
       acorn:
         specifier: ^8.18.0
         version: 8.18.0
@@ -216,8 +216,8 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@opencode-ai/sdk@1.18.13':
-    resolution: {integrity: sha512-JY9etiVcu1G/pZjaH2vjK/b8z54ujxaWCD1GziO4ADUhRM6m6zm2332bPGcxEfA6TwweiJfNlK6wVZQ0f/X4KQ==}
+  '@opencode-ai/sdk@1.18.30':
+    resolution: {integrity: sha512-uviJ+PZLc/D1szt33WGzzt/rqJ+IaNmRGBb+UcOXrcQANl8XXKJrp4CNQQ2UAnUJ3Ek+VqcamIwjtKHUW/OjOQ==}
 
   '@types/node@26.4.1':
     resolution: {integrity: sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==}
@@ -653,7 +653,7 @@ snapshots:
     dependencies:
       minipass: 7.1.3
 
-  '@opencode-ai/sdk@1.18.13':
+  '@opencode-ai/sdk@1.18.30':
     dependencies:
       cross-spawn: 7.0.6
 

--- a/sandbox-runner/agent-sandbox/pnpm-workspace.yaml
+++ b/sandbox-runner/agent-sandbox/pnpm-workspace.yaml
@@ -8,8 +8,8 @@
 allowBuilds:
   esbuild: true
   re2: true
-# 1.18.13 is younger than pnpm's release-age gate. Excluded rather than pinned lower: it is the
+# 1.18.30 is younger than pnpm's release-age gate. Excluded rather than pinned lower: it is the
 # version this was exercised against, and it must match the `opencode` CLI in template.ts. Names
 # one exact version, so it lapses on the next bump.
 minimumReleaseAgeExclude:
-  - '@opencode-ai/sdk@1.18.13'
+  - '@opencode-ai/sdk@1.18.30'

--- a/sandbox-runner/agent-sandbox/template.ts
+++ b/sandbox-runner/agent-sandbox/template.ts
@@ -79,7 +79,7 @@ export const template = Template()
   // SAME version as @opencode-ai/sdk below: they ship in lockstep, and agent-stream.js reads
   // message parts whose field names have moved between releases (see partsOf/toolCallsOf). Bump
   // both together.
-  .npmInstall('opencode-ai@1.18.13', { g: true })
+  .npmInstall('opencode-ai@1.18.30', { g: true })
   // Size only, not correctness. opencode ships its runtime as a ~180 MB platform binary in
   // optionalDependencies and on musl npm installs every variant matching the arch — 2 on arm64,
   // 4 on amd64 (both -baseline flavours too) — while executing exactly one.
@@ -110,7 +110,7 @@ export const template = Template()
   // together: here, the sibling Dockerfile, AND agent-sandbox/package.json (the host-local
   // backend, also ^6.28.0). agent-stream.js needs it to lift fetch's 300s headers timeout.
   .runCmd(
-    'mkdir -p /home/user && cd /home/user && npm install acorn@^8.18.0 acorn-walk@^8.3.5 re2@^1.26.1 @opencode-ai/sdk@1.18.13 undici@^6.28.0 && npm cache clean --force',
+    'mkdir -p /home/user && cd /home/user && npm install acorn@^8.18.0 acorn-walk@^8.3.5 re2@^1.26.1 @opencode-ai/sdk@1.18.30 undici@^6.28.0 && npm cache clean --force',
   )
   // HOME must match the runtime user (e2b runs sandboxes as `user`) so the runtime `opencode`
   // finds its config; PIP_BREAK_SYSTEM_PACKAGES lets the agent `pip install` further deps at

--- a/sandbox-runner/launcher/server.js
+++ b/sandbox-runner/launcher/server.js
@@ -378,7 +378,17 @@ function openAiCompatProviderBlock(mode, credential, model) {
   // the alternative and it is WRONG for GEMINI specifically: under the id `google`, OpenCode's
   // built-in provider plugin wins over the `npm` override and issues the NATIVE Gemini wire shape
   // with no Authorization header at all.
-  const block = { npm: '@ai-sdk/openai-compatible', options: creds };
+  // OPENAI is the one mode pointed at OpenAI's own endpoint, and it gets OpenAI's own package.
+  // `@ai-sdk/openai-compatible` always sends `max_tokens`, which the GPT-5.x reasoning line
+  // rejects outright ("Unsupported parameter ... use max_completion_tokens instead"), and OpenCode
+  // folds that 400 into an empty assistant turn, so the run surfaces as "opencode produced no
+  // usable reply" with a valid key and zero tokens. `@ai-sdk/openai` rewrites the field per model
+  // and is the only one of the two that can: knowing which models need it requires knowing the
+  // models, which is exactly what "any OpenAI-compatible endpoint" cannot assume. Upstream tracks
+  // the gap as opencode #45223, still open. Every other mode here IS such an endpoint, so the
+  // compat adapter stays right for them.
+  const npm = mode === OPENAI_COMPAT_MODE ? '@ai-sdk/openai' : '@ai-sdk/openai-compatible';
+  const block = { npm, options: creds };
   if (model) block.models = { [model]: {} };
   return { [OPENCODE_PROVIDER_NAME[mode]]: block };
 }

--- a/sandbox-runner/launcher/test/provider-dispatch.test.js
+++ b/sandbox-runner/launcher/test/provider-dispatch.test.js
@@ -100,7 +100,7 @@ test('providerConfig: GLM/GROK/CUSTOM/OPENAI each declare their own block with t
     options: { baseURL: 'https://my-endpoint.example/v1', apiKey: 'canary-custom' },
   });
   assert.deepEqual(providerConfig(OPENAI_CRED).provider['openai-direct'], {
-    npm: '@ai-sdk/openai-compatible',
+    npm: '@ai-sdk/openai',
     options: { baseURL: 'https://api.openai.com/v1', apiKey: 'canary-openai' },
   });
 });
@@ -179,7 +179,7 @@ test('providerConfig: an explicit ANTHROPIC base_url override still wins over th
 test('providerConfig: an OpenAI-compat block declares the run\'s own model', () => {
   const cfg = providerConfig({ provider: 'OPENAI', api_key: 'k' }, 'openai-direct/gpt-5.5');
   assert.deepEqual(cfg.provider['openai-direct'].models, { 'gpt-5.5': {} });
-  assert.equal(cfg.provider['openai-direct'].npm, '@ai-sdk/openai-compatible');
+  assert.equal(cfg.provider['openai-direct'].npm, '@ai-sdk/openai');
 });
 
 test('providerConfig: an OPENROUTER model keeps the slash in its own id', () => {


### PR DESCRIPTION
## What broke

Every Layer-2 triage run against `gpt-5.6-luna` was failing. The symptom was maximally misleading:

```
{"is_error":true,"error":"opencode produced no usable reply",
 "usage":{"input_tokens":0,"output_tokens":0,...}}
```

Zero tokens, valid key. That reads like a credential or connectivity problem, and it is neither.

## Why

`@ai-sdk/openai-compatible` always sends `max_tokens`. OpenAI's GPT-5.x reasoning line rejects it:

```
Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
```

OpenCode folds that 400 into an empty assistant turn, so a hard request-shape failure surfaced to us as an empty reply with no spend.

`@ai-sdk/openai` rewrites the field per model ([`openai-chat-language-model.ts`](https://github.com/vercel/ai/blob/main/packages/openai/src/chat/openai-chat-language-model.ts)) and is the only one of the two that can: knowing which models need it means knowing the models, which is exactly what "any OpenAI-compatible endpoint" cannot assume. Upstream tracks this as [opencode#45223](https://github.com/anomalyco/opencode/issues/45223), still open with no scheduled fix, so this does not wait on them.

## What changed

**`fix`** — `openAiCompatProviderBlock` selects `@ai-sdk/openai` for the `OPENAI` mode, `@ai-sdk/openai-compatible` for everything else. One line plus its rationale, and the two test assertions that pinned the old value.

**`chore`** — `opencode-ai` and `@opencode-ai/sdk` 1.18.13 → 1.18.30 across both recipes, `package.json`, and the lockfile. Independent of the fix; it stands on being current.

## For the reviewer

**The bump does not fix the bug, and that was measured rather than assumed.** 1.18.30 reproduces the failure identically while on the compat adapter, because [opencode#44710](https://github.com/anomalyco/opencode/pull/44710)'s provider gating does not recognise a custom `openai-compatible` block like `openai-direct`. Worth knowing before anyone concludes the bump was the cure.

**Why only the OPENAI mode moved.** The other modes are not the same case. `api.x.ai/v1` and `generativelanguage.googleapis.com/v1beta/openai/` are deliberately maintained OpenAI-*compatible* surfaces with a stated compatibility contract. OpenAI's `/v1` is the origin of the shape and owes nobody compatibility, which is precisely how it drifted. Pointing the compat adapter at a compat endpoint remains correct.

`@ai-sdk/xai` is a closer call than the others: it defaults to the same `api.x.ai/v1` base URL already in use and is a standalone implementation, so it is nearly a drop-in. It was left alone because there is no xAI key here to verify it with, and swapping a working provider blind inside an unrelated fix is how the next quiet zero-token failure gets introduced. Worth doing as its own change. Gemini is genuinely different: `@ai-sdk/google` uses a different endpoint path and an `x-goog-api-key` header instead of Bearer, so it is a credential-plumbing refactor, not a swap.

**The rest of the codebase was audited for the same pattern and is clean.** The Java backend cannot hit this defect: `.maxTokens(4096)` appears exactly once in the whole tree ([`ChatModelFactory.java:515`](backend/llm-runtime/src/main/java/ai/tessary/llm/ChatModelFactory.java#L515)), on the Anthropic builder, because Anthropic's API requires it. No OpenAI-wire path sets a token cap at all. Its OpenAI path already uses OpenAI's own LangChain4j client.

## Verification

- Reproduced and fixed against a real key inside the agent image, on both 1.18.13 and 1.18.30: compat adapter throws the 400, native package replies.
- Confirmed the key, auth, egress and model access were never the problem (`GET /v1/models` → 200, model present).
- Launcher suite 42/42.
- **Not yet run end-to-end through a rebuilt launcher against a live triage job.** That is the remaining gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)