### PR TITLE
ci: cut the backend gate by ~40% without dropping a check

### DIFF
--- a/.github/toolchain/Dockerfile
+++ b/.github/toolchain/Dockerfile
@@ -1,0 +1,185 @@
+# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: Apache-2.0
+#
+# The CI toolchain image for .github/workflows/check.yml.
+#
+# WHAT THIS IS FOR. That workflow spends six steps assembling toolchains before a single gate runs:
+# setup-java, pnpm/action-setup, setup-node, `pnpm install`, setup-python, and "Install Caddy". None
+# of that is work the gate cares about; it is the same set of installs on every PR, and the cost is
+# almost entirely network rather than compute. Baking them into one image turns those steps into a
+# `docker pull` the runner mostly has warm.
+#
+# THE FIVE TOOLCHAINS come straight out of scripts/check.sh's own header, which lists them and says
+# which gate needs each:
+#
+#   Temurin JDK 25   -- check-backend.sh hard-fails on any other major before Maven starts
+#   Node 24 + pnpm   -- check-frontend.sh runs tsc and a real vite build; pnpm's version is pinned
+#                       to frontend/package.json's `packageManager` field, not floated
+#   Python 3.13      -- six gates shell out to `python3` (version-consistency, open-boundary,
+#                       license-headers, caddy, compose-artifact, export-denylist)
+#   uv               -- check-classifier-parity.sh and the classifiers/ Python gates
+#   caddy            -- check-caddy.sh, which runs `caddy validate` and nothing else
+#
+# AND ONE THE LIST DOES NOT NAME: Maven. check-backend.sh's last line is `exec mvn -B -T 2 verify`,
+# and check.sh's header folds Maven into "Java" because ubuntu-latest ships it preinstalled and
+# actions/setup-java only had to supply the JDK. A container is not ubuntu-latest. Leave Maven out
+# and the backend gate dies on `mvn: command not found`, so it is pinned and installed here too.
+# If you are auditing this file against that header and counting to five, this is the sixth.
+#
+# EVERY VERSION IS PINNED AND EVERY DOWNLOAD IS CHECKSUM-VERIFIED. The point of an image is that
+# two runs a month apart get the identical toolchain; a `curl | sh` installer or an unpinned apt
+# package would give that away for nothing. Bumping any toolchain is editing its ARG pair — version
+# and hash move together, always.
+#
+# NOTE ON HASH ALGORITHMS, because they differ by upstream and mixing them up produces a confusing
+# failure rather than a clear one: Node and uv publish SHA-256, Caddy and Maven publish SHA-512.
+# The `sha256sum`/`sha512sum` call in each block matches what that project actually publishes.
+#
+# CADDY_VERSION AND CADDY_SHA512 BELOW ARE DUPLICATED IN check.yml's "Install Caddy" step. They are
+# deliberately the same pin and must be bumped together: while the `container:` key stays commented
+# out over there, that step is the one that actually runs, and a drift between the two would mean
+# the image and the live job validate Caddyfiles with different Caddy versions.
+
+FROM eclipse-temurin:25.0.4_7-jdk-noble
+
+# Toolchain pins. Each hash is copied verbatim from the publisher's own checksum file:
+#   NODE     https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt
+#   UV       https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/<asset>.sha256
+#   CADDY    https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_checksums.txt
+#   MAVEN    https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/<asset>.sha512
+ARG NODE_VERSION=24.21.0
+ARG NODE_SHA256=fd8e59d5a511510f6a298afb548f18c7d2b1be404d8b4a27d94fbe49f56cb2d6
+
+# Pinned to frontend/package.json's `packageManager` field. If you bump one, bump the other: the
+# whole reason to bake pnpm rather than let corepack resolve it at run time is that the image and
+# the lockfile agree by construction, and a silent divergence here would produce a store-layout
+# difference that only shows up as a confusing `pnpm install --frozen-lockfile` failure.
+ARG PNPM_VERSION=11.15.1
+
+ARG PYTHON_VERSION=3.13
+ARG UV_VERSION=0.12.11
+ARG UV_SHA256=4ae93e0f148a18434cc094072547cec88912fc4a72b984183c7d0d0e9586cb5e
+ARG CADDY_VERSION=2.11.4
+ARG CADDY_SHA512=8220d1f013b6f27510247b2360c9e0ca9f018feebd82515f07635318b34ff9777ccc8fd0b6e6f2486ce3a33fe389fbb7db12d05baa474f4587509fb4f5ebf1c9
+ARG MAVEN_VERSION=3.9.16
+ARG MAVEN_SHA512=831a8591fe20c8243b1dbe7d71e3244f31d1665b0804b2e825e38cbbe5ce0cafb8338851f90780735568773e0a6cd07bbec107cda0b896b008b861075358b6f6
+
+SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
+
+# The only apt install in this file, and it is base OS plumbing rather than a toolchain: curl and
+# ca-certificates to fetch the pinned tarballs, xz-utils because Node ships .tar.xz, git because
+# check-export-denylist.sh and several gates shell out to it, and bash because every scripts/*.sh
+# starts with `#!/usr/bin/env bash` and Ubuntu's default /bin/sh is dash.
+RUN apt-get update \
+ && apt-get install --no-install-recommends -y \
+      bash \
+      ca-certificates \
+      curl \
+      git \
+      tar \
+      xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+
+# ---------------------------------------------------------------------------------------------
+# Maven
+# ---------------------------------------------------------------------------------------------
+# backend/.mvn/extensions.xml loads the Maven build-cache extension, which is a Maven 3.9 feature;
+# do not drift this to Maven 4 without reading that file and .mvn/maven-build-cache-config.xml.
+RUN set -euo pipefail; \
+    cd /tmp; \
+    curl --fail --location --silent --show-error --retry 3 --retry-all-errors \
+         -o maven.tar.gz \
+         "https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"; \
+    echo "${MAVEN_SHA512}  maven.tar.gz" | sha512sum --check --strict -; \
+    mkdir -p /opt/maven; \
+    tar -xzf maven.tar.gz -C /opt/maven --strip-components=1; \
+    rm maven.tar.gz; \
+    ln -s /opt/maven/bin/mvn /usr/local/bin/mvn; \
+    mvn --version
+
+# ---------------------------------------------------------------------------------------------
+# Node + pnpm
+# ---------------------------------------------------------------------------------------------
+# --strip-components=1 lands node's bin/, lib/, include/ and share/ directly under /usr/local, which
+# is how the official node image does it and why no PATH change is needed.
+RUN set -euo pipefail; \
+    cd /tmp; \
+    curl --fail --location --silent --show-error --retry 3 --retry-all-errors \
+         -o node.tar.xz \
+         "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"; \
+    echo "${NODE_SHA256}  node.tar.xz" | sha256sum --check --strict -; \
+    tar -xJf node.tar.xz -C /usr/local --strip-components=1; \
+    rm -f node.tar.xz /usr/local/CHANGELOG.md /usr/local/LICENSE /usr/local/README.md; \
+    node --version; \
+    npm --version
+
+# Installed through npm at an exact version rather than from pnpm's own release tarball: npm
+# verifies the registry tarball's integrity hash over TLS, so the pin is still exact, and it avoids
+# a second hardcoded hash that would have to be bumped in lockstep with package.json anyway.
+# Corepack is deliberately not used — it resolves `packageManager` at run time, which is a network
+# call on every job and defeats the point of baking the toolchain in.
+RUN set -euo pipefail; \
+    npm install --global "pnpm@${PNPM_VERSION}"; \
+    npm cache clean --force; \
+    pnpm --version
+
+# ---------------------------------------------------------------------------------------------
+# uv, and Python 3.13 through it
+# ---------------------------------------------------------------------------------------------
+# Ubuntu 24.04 (noble) ships Python 3.12, and 3.13 is not in its archive. The usual fix is the
+# deadsnakes PPA, which is a third-party apt repo — exactly the machinery Layer 3 removed from
+# check.yml's Caddy step, and it would reintroduce an unpinned, network-dependent install. uv is
+# already a required toolchain here and can install a managed CPython itself, so 3.13 comes from
+# the tool the repo already depends on rather than from a fourth package source.
+RUN set -euo pipefail; \
+    cd /tmp; \
+    curl --fail --location --silent --show-error --retry 3 --retry-all-errors \
+         -o uv.tar.gz \
+         "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz"; \
+    echo "${UV_SHA256}  uv.tar.gz" | sha256sum --check --strict -; \
+    tar -xzf uv.tar.gz -C /usr/local/bin --strip-components=1; \
+    rm uv.tar.gz; \
+    uv --version
+
+# Set as ENV, not just ARG, so that `uv run` at job time resolves the interpreter baked in here
+# instead of downloading its own into a container-local HOME on first use.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
+
+# The gates invoke the interpreter as bare `python3` (and check-classify-service.sh's helpers as
+# `python`), so both names have to resolve on PATH; a uv-managed install is only discoverable
+# through uv until it is linked.
+RUN set -euo pipefail; \
+    uv python install "${PYTHON_VERSION}"; \
+    ln -s "$(uv python find "${PYTHON_VERSION}")" /usr/local/bin/python3; \
+    ln -s /usr/local/bin/python3 /usr/local/bin/python; \
+    python3 --version; \
+    python --version
+
+# ---------------------------------------------------------------------------------------------
+# Caddy
+# ---------------------------------------------------------------------------------------------
+# Same pin, same tarball and same SHA-512 as check.yml's "Install Caddy" step; see the note at the
+# top of this file about keeping the two in step. Only the binary is extracted — the tarball's
+# LICENSE and README.md have no business in /usr/local/bin.
+RUN set -euo pipefail; \
+    cd /tmp; \
+    curl --fail --location --silent --show-error --retry 3 --retry-all-errors \
+         -o caddy.tar.gz \
+         "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/caddy_${CADDY_VERSION}_linux_amd64.tar.gz"; \
+    echo "${CADDY_SHA512}  caddy.tar.gz" | sha512sum --check --strict -; \
+    tar -xzf caddy.tar.gz -C /usr/local/bin caddy; \
+    chmod 0755 /usr/local/bin/caddy; \
+    rm caddy.tar.gz; \
+    caddy version
+
+# A last assertion that every tool the gate reaches for is actually on PATH in the final image, run
+# at build time so a broken image fails in the build that produced it rather than in someone's PR.
+# `command -v` and not a version call: this is about resolvability, and each block above already
+# proved its own tool executes.
+RUN set -euo pipefail; \
+    for t in java mvn node npm pnpm python3 uv caddy git; do \
+      command -v "$t" >/dev/null || { echo "toolchain image: '$t' is not on PATH" >&2; exit 1; }; \
+    done; \
+    echo "toolchain image: java=$(java -version 2>&1 | head -1)"
+
+WORKDIR /workspace

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,6 +37,53 @@ jobs:
   open-edition:
     name: check.sh (the full gate manifest, --edition open)
     runs-on: ubuntu-latest
+
+    # -----------------------------------------------------------------------------------------
+    # AUTHORED BUT NOT ARMED — the toolchain image, .github/toolchain/Dockerfile.
+    # -----------------------------------------------------------------------------------------
+    # Same precedent as codeql.yml at the top of that file: the change is written out in full and
+    # left commented, because a prerequisite that is not this repo's to satisfy today is missing.
+    # A silently absent file would look like nobody considered baking the toolchain; a comment
+    # claiming it would work without the workflow to point at is a claim nobody can check.
+    #
+    # WHAT IT WOULD DO: the six steps between `checkout` and `check.sh` exist only to assemble
+    # toolchains — setup-java, pnpm/action-setup, setup-node, `pnpm install`, setup-python, and
+    # "Install Caddy". .github/toolchain/Dockerfile bakes all of them (plus Maven, which
+    # ubuntu-latest gave us for free and a container does not). With the `container:` key below,
+    # every one of those steps except `pnpm install` deletes, and the job's setup cost becomes a
+    # `docker pull`.
+    #
+    # BLOCKER 1 — NOTHING BUILDS OR PUBLISHES THE IMAGE YET. `container:` takes a registry
+    # reference, not a Dockerfile path; GitHub will not build one for you. The image has to exist
+    # in a registry before this key can name it. release.yml is the natural home: it already
+    # authenticates to Docker Hub and publishes under `tessaryai/tessary` (its DOCKER_REPO env),
+    # so a `ci-toolchain` tag alongside the service tags needs no new registry, no new secret and
+    # no new account. That publishing step is not written yet, deliberately — it is a separate
+    # change with its own tagging and freshness questions (when does the image get rebuilt? what
+    # pins the workflow to a specific build rather than a moving tag?).
+    #
+    # BLOCKER 2 — TESTCONTAINERS NEEDS THE DOCKER SOCKET, AND CONTAINER JOBS DO NOT GET IT.
+    # check-backend.sh's `mvn verify` drives a real pgvector Postgres through Testcontainers.
+    # On `runs-on: ubuntu-latest` that works because the steps run on the host, which has Docker.
+    # Inside a job container there is no /var/run/docker.sock unless it is mounted in explicitly,
+    # and even then Ryuk and the container's view of the test's network need proving. This must be
+    # demonstrated green on a branch before arming — an image that pulls fast and then fails every
+    # backend test is strictly worse than the six setup steps it replaced.
+    #
+    # BLOCKER 3 — THE ACTIONS' CACHES GO WITH THEM. setup-java's `cache: maven` and setup-node's
+    # `cache: pnpm` are doing real work on every run. Deleting those steps deletes the caches too,
+    # so this trade is only a win once the equivalent actions/cache entries are written, or once
+    # it is measured and the pull-vs-cache arithmetic actually comes out ahead.
+    #
+    # ARMING IS UNCOMMENTING THE TWO LINES BELOW (with a real tag in place of `latest`) and then
+    # deleting the toolchain setup steps. Nothing else in this file depends on it.
+    #
+    # container:
+    #   image: docker.io/tessaryai/tessary:ci-toolchain-latest
+    #   # Testcontainers, per BLOCKER 2. Unverified — this is the shape the fix takes, not a
+    #   # configuration anyone has seen pass.
+    #   options: --volume /var/run/docker.sock:/var/run/docker.sock
+
     steps:
       - uses: actions/checkout@v7
 
@@ -70,13 +117,59 @@ jobs:
       # Major-pinned, not exact-pinned: see drift-checks.yml's vendored-plugin job for why.
 
       - name: Install Caddy
+        # A pinned release tarball, not the Cloudsmith apt repo. The apt route cost 41 seconds of
+        # this job, and almost none of it was the download: it ran `apt-get update` TWICE (once to
+        # be able to install the keyring packages, once more after writing the new sources list),
+        # and installed debian-keyring, debian-archive-keyring and apt-transport-https purely so
+        # apt could be taught to trust a third-party repo. All of that machinery existed to deliver
+        # one statically linked binary.
+        #
+        # Nothing here needs the apt package's extras. scripts/check-caddy.sh only ever runs
+        # `caddy validate` — no systemd unit, no `caddy` user, no /etc/caddy, no service that has
+        # to survive a reboot. A binary on PATH is the entire toolchain that gate wants.
+        #
+        # PINNED ON PURPOSE. An unpinned `apt-get install caddy` meant this gate's result depended
+        # on which Caddy was current the day it ran, so a Caddyfile that validated on Monday could
+        # red on Friday with nothing in the diff. Bumping is a two-line edit: CADDY_VERSION and
+        # CADDY_SHA512 move together, and the hash is copied verbatim out of the release's own
+        # caddy_<version>_checksums.txt. Note that file is SHA-512, not SHA-256 — hence
+        # `sha512sum` below; feeding a 64-char SHA-256 to it fails with a format error, which is
+        # the correct outcome but an easy one to misread as a corrupted download.
+        env:
+          CADDY_VERSION: 2.11.4
+          CADDY_SHA512: 8220d1f013b6f27510247b2360c9e0ca9f018feebd82515f07635318b34ff9777ccc8fd0b6e6f2486ce3a33fe389fbb7db12d05baa474f4587509fb4f5ebf1c9
         run: |
-          sudo apt-get update
-          sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl
-          curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-          curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
-          sudo apt-get update
-          sudo apt-get install -y caddy
+          set -euo pipefail
+          tarball="caddy_${CADDY_VERSION}_linux_amd64.tar.gz"
+          workdir="$(mktemp -d)"
+          cd "$workdir"
+
+          # --fail matters more than it looks: without it curl happily writes a 404 page to the
+          # output file and exits 0, and the failure then surfaces one line later as a checksum
+          # mismatch, which reads like a supply-chain event rather than a wrong version string.
+          # --retry covers a flaky release CDN without papering over a genuinely absent asset,
+          # since a 404 is not retried into success.
+          curl --fail --location --silent --show-error \
+               --retry 3 --retry-all-errors \
+               --output "$tarball" \
+               "https://github.com/caddyserver/caddy/releases/download/v${CADDY_VERSION}/${tarball}"
+
+          # The gate. `set -e` plus a non-zero sha512sum is what stops the job; there is no
+          # fallback path and deliberately no `|| true` anywhere in this step. If this line fails,
+          # the run must die here rather than continue to `check.sh` and fail there with
+          # "caddy: command not found", which points at the wrong thing.
+          echo "${CADDY_SHA512}  ${tarball}" | sha512sum --check --strict -
+
+          # Extract only the binary; the tarball also carries LICENSE and README.md, which have no
+          # business in /usr/local/bin.
+          sudo tar -xzf "$tarball" -C /usr/local/bin caddy
+          sudo chmod 0755 /usr/local/bin/caddy
+          cd / && rm -rf "$workdir"
+
+          # Prove it before check-caddy.sh has to. A binary that unpacked but will not execute
+          # (wrong arch, missing loader) fails here with a legible message instead of surfacing as
+          # that gate's "the dev Caddyfile does not validate".
+          caddy version
 
       # CI never loads the Taskfile, so this calls the script directly.
       - run: bash scripts/check.sh --edition open

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -239,7 +239,7 @@ tasks:
       # Through the script, not an inline mvn: scripts/check-backend.sh hard-fails on any
       # JDK that is not major 25 BEFORE Maven starts, and this target used to bypass that guard and
       # surface the mismatch as an opaque PMD or compiler crash deep in the reactor. Its last line
-      # is `exec mvn -B verify "$@"`, so the profile threads straight through and there is exactly
+      # is `exec mvn -B -T 2 verify "$@"`, so the profile threads straight through and there is exactly
       # ONE definition of the backend gate for both editions. `task check:open` runs the same line.
       - bash scripts/check-backend.sh -P '!paid'
 
@@ -545,7 +545,7 @@ tasks:
   # defined once and "local green ⇒ CI green" holds by construction (no drift to keep in sync):
   #   contract:check + CI contract job -> scripts/check-contract-consistency.sh (vendored contract drift)
   #   contract:plugin + CI vendored-plugin job -> scripts/check-vendored-plugin.sh (validator rules + freshness)
-  #   backend:check  + CI backend job  -> scripts/check-backend.sh  (mvn -B verify)
+  #   backend:check  + CI backend job  -> scripts/check-backend.sh  (mvn -B -T 2 verify)
   #   frontend:check + CI frontend job -> scripts/check-frontend.sh (pnpm run lint + pnpm run test [the
   #                                      route render smoke test] + pnpm run build, then an assertion
   #                                      over dist/ that no paid chunk or copy is in it)

--- a/backend/app/src/test/java/ai/tessary/ContextLoadsTest.java
+++ b/backend/app/src/test/java/ai/tessary/ContextLoadsTest.java
@@ -15,25 +15,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Smoke test that the Spring context loads end-to-end and tenancy works.
- * Auth is disabled (WORKOS_* unset) so the filter passes everything through
- * — we exercise the data layer directly.
+ * Auth is off because {@code TestAuthDisabledInitializer} sets {@code tessary.auth.disabled=true}
+ * for every test context, so the filter passes everything through and this exercises the data layer
+ * directly.
  */
 @SpringBootTest
 class ContextLoadsTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-        // workos.* deliberately blank. That alone no longer makes AuthFilter no-op --
-        // TestAuthDisabledInitializer supplies tessary.auth.disabled=true for every test context, and
-        // the filter needs both. See that initializer for why the suite states it once rather than
-        // in 115 files.
-    }
 
     @Autowired
     SourceService sourceService;

--- a/backend/app/src/test/java/ai/tessary/alert/AlertChannelDeliveryTest.java
+++ b/backend/app/src/test/java/ai/tessary/alert/AlertChannelDeliveryTest.java
@@ -34,8 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for alert channels. Exercised against the real pgvector Postgres
@@ -52,11 +50,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class AlertChannelDeliveryTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantService tenants;

--- a/backend/app/src/test/java/ai/tessary/alert/AlertingIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/alert/AlertingIntegrationTest.java
@@ -23,8 +23,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for alerting: the roll-ups and case notifications that are all alerting still decides.
@@ -36,11 +34,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class AlertingIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantService tenants;

--- a/backend/app/src/test/java/ai/tessary/apidoc/OpenApiSpecDriftTest.java
+++ b/backend/app/src/test/java/ai/tessary/apidoc/OpenApiSpecDriftTest.java
@@ -40,7 +40,6 @@ class OpenApiSpecDriftTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         // Matches the app's normal (auth-enforced) posture rather than the suite's global
         // unauthenticated default -- say so directly rather than configuring a fake
         // external-provider key as an indirect toggle. See TestAuthDisabledInitializer's javadoc.

--- a/backend/app/src/test/java/ai/tessary/auth/AuthControllerTest.java
+++ b/backend/app/src/test/java/ai/tessary/auth/AuthControllerTest.java
@@ -33,7 +33,6 @@ class AuthControllerTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.auth.cookie-password", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("workos.api-key", () -> "");
         r.add("workos.client-id", () -> "");

--- a/backend/app/src/test/java/ai/tessary/auth/AuthProviderConfigTest.java
+++ b/backend/app/src/test/java/ai/tessary/auth/AuthProviderConfigTest.java
@@ -29,7 +29,6 @@ class AuthProviderConfigTest {
 
         @DynamicPropertySource
         static void props(DynamicPropertyRegistry r) {
-            r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
             r.add("workos.api-key", () -> "");
             r.add("workos.client-id", () -> "");
         }
@@ -53,7 +52,6 @@ class AuthProviderConfigTest {
 
         @DynamicPropertySource
         static void props(DynamicPropertyRegistry r) {
-            r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
             r.add("workos.api-key", () -> "sk_test_fake");
             r.add("workos.client-id", () -> "client_fake");
         }

--- a/backend/app/src/test/java/ai/tessary/auth/SignupPolicyIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/auth/SignupPolicyIntegrationTest.java
@@ -32,6 +32,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -44,11 +45,13 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @SpringBootTest
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+// Own context on purpose: it holds the instance-wide signup policy at `invite`/`domain` across ordered methods, which
+// would refuse every other class's signup while it is held.
+@TestPropertySource(properties = "test.context-group=signup-policy")
 class SignupPolicyIntegrationTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.auth.cookie-password", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("workos.api-key", () -> "");
         r.add("workos.client-id", () -> "");

--- a/backend/app/src/test/java/ai/tessary/auth/TenantPathResolverTest.java
+++ b/backend/app/src/test/java/ai/tessary/auth/TenantPathResolverTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -28,11 +26,6 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @SpringBootTest
 class TenantPathResolverTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantPathResolver resolver;

--- a/backend/app/src/test/java/ai/tessary/cases/CaseLedgerTest.java
+++ b/backend/app/src/test/java/ai/tessary/cases/CaseLedgerTest.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * The case lifecycle state machine, against real Postgres so the partial indexes and the ISO-text
@@ -35,11 +36,13 @@ import org.springframework.test.context.DynamicPropertySource;
  * case on the next worker tick, which is how "resolve" comes to look broken.
  */
 @SpringBootTest
+// Own context on purpose: CaseWorker's sweep is parked here, and a shared database would let another class's findings
+// reconcile these cases away.
+@TestPropertySource(properties = "test.context-group=case-ledger")
 class CaseLedgerTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         // Park CaseWorker's sweep. It reconciles every active project from the REAL sources, which
         // report nothing for a fixture project — so a tick landing mid-test would auto-resolve the
         // cases these assertions just opened.

--- a/backend/app/src/test/java/ai/tessary/cases/CaseRepositoryIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/cases/CaseRepositoryIntegrationTest.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * The two partial indexes the baseline changeset defines on {@code eval_case}, the display-number
@@ -40,11 +41,13 @@ import org.springframework.test.context.DynamicPropertySource;
  * that the string was assembled.
  */
 @SpringBootTest
+// Own context on purpose: CaseWorker's sweep is parked here, and its assertions read the case table without a project
+// filter.
+@TestPropertySource(properties = "test.context-group=case-repository")
 class CaseRepositoryIntegrationTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.cases.heartbeat-ms", () -> "3600000");
     }
 

--- a/backend/app/src/test/java/ai/tessary/cases/CaseServiceTest.java
+++ b/backend/app/src/test/java/ai/tessary/cases/CaseServiceTest.java
@@ -33,14 +33,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 /** Case lifecycle as a human drives it: resolve, mute, unmute, and how a case is looked up. */
 @SpringBootTest
+// Own context on purpose: CaseWorker's sweep is parked here, and the lifecycle assertions depend on no other writer
+// touching the case rows.
+@TestPropertySource(properties = "test.context-group=case-service")
 class CaseServiceTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.cases.heartbeat-ms", () -> "3600000");
     }
 

--- a/backend/app/src/test/java/ai/tessary/cases/MetricDriftCaseGateIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/cases/MetricDriftCaseGateIntegrationTest.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The triage gate, against the query that enforces it.
@@ -50,11 +48,6 @@ class MetricDriftCaseGateIntegrationTest {
      * are about. A test that wants the other arm passes its own.
      */
     private static final Duration QUIET_WINDOW = Duration.ofDays(1);
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     MetricDriftSource source;

--- a/backend/app/src/test/java/ai/tessary/cases/ToolErrorCaseRenderingIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/cases/ToolErrorCaseRenderingIntegrationTest.java
@@ -47,7 +47,6 @@ class ToolErrorCaseRenderingIntegrationTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.cases.heartbeat-ms", () -> "3600000");
     }
 

--- a/backend/app/src/test/java/ai/tessary/ci/PreDeploySignalLoopIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/ci/PreDeploySignalLoopIntegrationTest.java
@@ -44,7 +44,6 @@ class PreDeploySignalLoopIntegrationTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.predeploy.enabled", () -> "true"); // activate the loop (write + read)
     }
 

--- a/backend/app/src/test/java/ai/tessary/classifier/CallSiteFactRewindIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/CallSiteFactRewindIntegrationTest.java
@@ -28,8 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The chicken-and-egg this feature exists to break, end to end against the real pgvector Postgres.
@@ -52,11 +50,6 @@ import org.springframework.test.context.DynamicPropertySource;
 @SpringBootTest
 @Import(TurnGrainTestDetectionConfig.class)
 class CallSiteFactRewindIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     private static final String SCHEMA =
             "{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"}},\"required\":[\"answer\"]}";

--- a/backend/app/src/test/java/ai/tessary/classifier/CallSiteOutputSchemaIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/CallSiteOutputSchemaIntegrationTest.java
@@ -14,8 +14,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Round-trips the Malformed Output built-in's schema seam against the real pgvector Postgres
@@ -25,11 +23,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class CallSiteOutputSchemaIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     private static final String SCHEMA =
             "{\"type\":\"object\",\"properties\":{\"answer\":{\"type\":\"string\"}},\"required\":[\"answer\"]}";

--- a/backend/app/src/test/java/ai/tessary/classifier/ClassifierArmingIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/ClassifierArmingIntegrationTest.java
@@ -23,8 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for classifier arming — the replacement for the threshold {@code alert_rule} path.
@@ -36,11 +34,6 @@ import org.springframework.test.context.DynamicPropertySource;
 @SpringBootTest
 @Import(StubEncoderScorerConfig.class)
 class ClassifierArmingIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     ClassifierArming arming;

--- a/backend/app/src/test/java/ai/tessary/classifier/ClassifierCursorKeysetIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/ClassifierCursorKeysetIntegrationTest.java
@@ -51,7 +51,6 @@ class ClassifierCursorKeysetIntegrationTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.classifier.batch-size", () -> String.valueOf(BATCH));
     }
 

--- a/backend/app/src/test/java/ai/tessary/classifier/ClassifierDailyVolumeIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/ClassifierDailyVolumeIntegrationTest.java
@@ -23,8 +23,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for the per-classifier daily trace-volume read behind
@@ -36,11 +34,6 @@ import org.springframework.test.context.DynamicPropertySource;
 @SpringBootTest
 @Import(StubEncoderScorerConfig.class)
 class ClassifierDailyVolumeIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/ClassifierDefinitionIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/ClassifierDefinitionIntegrationTest.java
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for the signal <b>definition</b> model + lifecycle: the built-in catalog seeds
@@ -29,11 +27,6 @@ import org.springframework.test.context.DynamicPropertySource;
 @SpringBootTest
 @Import(TurnGrainTestDetectionConfig.class)
 class ClassifierDefinitionIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     ClassifierService service;

--- a/backend/app/src/test/java/ai/tessary/classifier/ClassifierPrecisionModeIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/ClassifierPrecisionModeIntegrationTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for the discovery-vs-tracking precision modes. The same frustration signal definition
@@ -41,11 +39,6 @@ import org.springframework.test.context.DynamicPropertySource;
 @SpringBootTest
 @Import({StubEncoderScorerConfig.class, TurnGrainTestDetectionConfig.class})
 class ClassifierPrecisionModeIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/ClassifierTurnGrainIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/ClassifierTurnGrainIntegrationTest.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Frustration is {@link ClassifierModelModule.Grain#TURN}: its subject is what the user said, and the
@@ -50,11 +48,6 @@ import org.springframework.test.context.DynamicPropertySource;
 class ClassifierTurnGrainIntegrationTest {
 
     private static final String FRUSTRATED = "this is frustrating, you're not listening";
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/GroundingEvidenceIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/GroundingEvidenceIntegrationTest.java
@@ -28,8 +28,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Executes {@link SubstrateReadRepository#groundingEvidence} against the real Postgres.
@@ -43,11 +41,6 @@ import org.springframework.test.context.DynamicPropertySource;
 @SpringBootTest
 @Import(StubEncoderScorerConfig.class)
 class GroundingEvidenceIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/ManualEscalationIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/ManualEscalationIntegrationTest.java
@@ -39,8 +39,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Layer-2 is a hand-pressed button, and this is the surface behind it.
@@ -62,11 +60,6 @@ class ManualEscalationIntegrationTest {
      * tests are about. A test that wants the other arm passes its own.
      */
     private static final Duration QUIET_WINDOW = Duration.ofDays(1);
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     FindingService behavior;

--- a/backend/app/src/test/java/ai/tessary/classifier/PartnerCatalogTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/PartnerCatalogTest.java
@@ -22,8 +22,6 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The partner-facing classifier catalog, against real {@code org_feature_flag} rows.
@@ -54,11 +52,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class PartnerCatalogTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     /**
      * The classifiers a launch partner must not see. The three launch classifiers

--- a/backend/app/src/test/java/ai/tessary/classifier/SecretLeakRedactionSeamIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/SecretLeakRedactionSeamIntegrationTest.java
@@ -29,8 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The seam left untested: an OTLP batch carrying a credential goes in through the ingest
@@ -41,11 +39,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class SecretLeakRedactionSeamIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     OtlpIngestService otlp;

--- a/backend/app/src/test/java/ai/tessary/classifier/SubstrateLivenessIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/SubstrateLivenessIntegrationTest.java
@@ -19,8 +19,6 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for the onboarding live-trace detector ({@link SubstrateReadRepository#hasSpans}),
@@ -37,11 +35,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class SubstrateLivenessIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SubstrateReadRepository substrate;

--- a/backend/app/src/test/java/ai/tessary/classifier/TriageAutoEscalationIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/TriageAutoEscalationIntegrationTest.java
@@ -38,8 +38,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 /**
@@ -64,11 +62,6 @@ class TriageAutoEscalationIntegrationTest {
      * are about. A test that wants the other arm passes its own.
      */
     private static final Duration QUIET_WINDOW = Duration.ofDays(1);
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     /**
      * The flag adapter, stubbed, and only the adapter.

--- a/backend/app/src/test/java/ai/tessary/classifier/finding/BehaviorBlockedRecurrenceIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/finding/BehaviorBlockedRecurrenceIntegrationTest.java
@@ -17,8 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * What happens when a cause a human called a deviation happens again.
@@ -36,11 +34,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class BehaviorBlockedRecurrenceIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     FindingRepository findings;

--- a/backend/app/src/test/java/ai/tessary/classifier/finding/BehaviorFindingOnsetTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/finding/BehaviorFindingOnsetTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * When a finding's onset moves and when it must not — the rule {@code CaseLedger.isNewSpell} reads to
@@ -40,11 +38,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class BehaviorFindingOnsetTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     FindingRepository findings;

--- a/backend/app/src/test/java/ai/tessary/classifier/finding/SharedFindingTableIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/finding/SharedFindingTableIntegrationTest.java
@@ -26,8 +26,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The invariants the shared {@code finding} table introduces, against the real schema: every one of
@@ -39,11 +37,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class SharedFindingTableIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     FindingRepository findings;

--- a/backend/app/src/test/java/ai/tessary/classifier/metric/MetricBaselineRepositoryTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/metric/MetricBaselineRepositoryTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * {@code metric_baseline} and its repository against the real Postgres, because the two things most
@@ -46,11 +44,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class MetricBaselineRepositoryTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     MetricBaselineRepository baselines;

--- a/backend/app/src/test/java/ai/tessary/classifier/metric/MetricDriftSweepIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/metric/MetricDriftSweepIntegrationTest.java
@@ -39,8 +39,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * {@link MetricDriftSweep} end to end against the real Postgres, for the two things a sweep has to get
@@ -63,11 +61,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class MetricDriftSweepIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     /**
      * The shipped shape at the smallest sizes the clamps allow, so a window closes within a fixture

--- a/backend/app/src/test/java/ai/tessary/classifier/metric/MetricFindingResolveIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/metric/MetricFindingResolveIntegrationTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The correction loop for a {@code distribution_shift} finding — PROGRAM.md §9, the half of the
@@ -59,11 +57,6 @@ class MetricFindingResolveIntegrationTest {
      * are about. A test that wants the other arm passes its own.
      */
     private static final Duration QUIET_WINDOW = Duration.ofDays(1);
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     FindingService drift;

--- a/backend/app/src/test/java/ai/tessary/classifier/metric/MetricSourceTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/metric/MetricSourceTest.java
@@ -34,8 +34,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for {@link MetricSource} against the real pgvector Postgres (Testcontainers), because every
@@ -64,11 +62,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class MetricSourceTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/substrate/BehaviorEventTimeReadIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/substrate/BehaviorEventTimeReadIntegrationTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The FORMAT of the event time the sweep reads, against real Postgres and the real driver.
@@ -39,11 +37,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class BehaviorEventTimeReadIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/substrate/BehaviorTailWindowIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/substrate/BehaviorTailWindowIntegrationTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The trailing-window read the saturation gate falls back to when a corpus has stopped growing.
@@ -34,11 +32,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class BehaviorTailWindowIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/substrate/ConversationThreadAssemblerIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/substrate/ConversationThreadAssemblerIntegrationTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * DB-backed proof that {@link ConversationThreadAssembler} walks a whole conversation (not just the
@@ -38,11 +36,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class ConversationThreadAssemblerIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/substrate/TraceScopeIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/substrate/TraceScopeIntegrationTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Which call site a trace is scoped to: the choice that decides which baseline it is fitted into.
@@ -46,11 +44,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class TraceScopeIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/classifier/toolerror/ToolErrorClassifierIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/toolerror/ToolErrorClassifierIntegrationTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The tool-error classifier (launch segment C) against a real database, end to end: ingested rows in,
@@ -67,11 +65,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class ToolErrorClassifierIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     private static final String TOOL = "search_docs";
 

--- a/backend/app/src/test/java/ai/tessary/classifier/worker/ClassifierJobRepositoryTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/worker/ClassifierJobRepositoryTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Exercises the signal sweep queue's dead-letter budget against the real pgvector
@@ -36,11 +34,6 @@ class ClassifierJobRepositoryTest {
 
     private static final int MAX_ATTEMPTS = 5;
     private static final long LONG_COOLDOWN_SECONDS = 3600;
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     ClassifierJobRepository jobs;

--- a/backend/app/src/test/java/ai/tessary/classifier/worker/ClassifierWorkerDeadLetterTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/worker/ClassifierWorkerDeadLetterTest.java
@@ -34,6 +34,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * A sweep that keeps throwing is dead-lettered after {@code maxAttempts} consecutive failures:
@@ -44,13 +45,15 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 @Import({ThrowingEncoderScorerConfig.class, TurnGrainTestDetectionConfig.class})
+// Own context on purpose: the zero dead-letter cooldown it needs would make every other class's failed job revive
+// instantly.
+@TestPropertySource(properties = "test.context-group=classifier-dead-letter")
 class ClassifierWorkerDeadLetterTest {
 
     private static final int MAX_ATTEMPTS = 5;
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         // A near-zero cooldown lets the test drive an automatic revival without a real-time wait.
         r.add("tessary.classifier.dead-letter-cooldown-seconds", () -> "0");
     }

--- a/backend/app/src/test/java/ai/tessary/classifier/worker/ClassifierWorkerIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/classifier/worker/ClassifierWorkerIntegrationTest.java
@@ -34,8 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * End-to-end acceptance for the async signal sweep: with the worker enabled, the structurally-
@@ -48,11 +46,6 @@ import org.springframework.test.context.DynamicPropertySource;
 @SpringBootTest
 @Import({StubEncoderScorerConfig.class, TurnGrainTestDetectionConfig.class})
 class ClassifierWorkerIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/config/TestSecretKeyInitializer.java
+++ b/backend/app/src/test/java/ai/tessary/config/TestSecretKeyInitializer.java
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+package ai.tessary.config;
+
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/**
+ * Supplies every Spring test context with the AES-GCM key {@code SecretBox} needs, since a
+ * {@code @SpringBootTest} that seals or opens an ingestion-source credential fails without one and
+ * no test cares what the bytes are.
+ *
+ * <p>Registered globally in {@code src/test/resources/META-INF/spring.factories} beside
+ * {@code TestcontainersPostgresInitializer} and {@code TestAuthDisabledInitializer}, so no test
+ * needs per-class wiring.
+ *
+ * <p>This replaces 80 byte-identical {@code @DynamicPropertySource} copies, and the reason is
+ * throughput rather than tidiness: {@code DynamicPropertiesContextCustomizer} equality compares the
+ * {@code Set<Method>} it was built from, so 80 declaring classes meant 80 unequal customizers, 80
+ * distinct context cache keys, and 80 Spring boots of the same application.
+ *
+ * <p>Only sets {@code tessary.secret-key} when the property is not already present, so a test that
+ * needs a different key (a rotation or a decrypt-failure case) can still state its own.
+ */
+public class TestSecretKeyInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    private static final String TEST_KEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+    @Override
+    public void initialize(ConfigurableApplicationContext applicationContext) {
+        // application.yaml carries `secret-key: ${TESSARY_SECRET_KEY:}`, so the key is always
+        // *present* and always blank unless something supplies it; containsProperty would therefore
+        // never be false. Check for a non-blank value instead, which is what a test overriding this
+        // would actually set.
+        String existing = applicationContext.getEnvironment().getProperty("tessary.secret-key");
+        if (existing == null || existing.isBlank()) {
+            TestPropertyValues.of("tessary.secret-key=" + TEST_KEY).applyTo(applicationContext.getEnvironment());
+        }
+    }
+}

--- a/backend/app/src/test/java/ai/tessary/db/SchemaCleaningTestExecutionListener.java
+++ b/backend/app/src/test/java/ai/tessary/db/SchemaCleaningTestExecutionListener.java
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+package ai.tessary.db;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import javax.sql.DataSource;
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+
+/**
+ * Empties the schema after every test class, so classes sharing a Spring context cannot read each
+ * other's rows.
+ *
+ * <p>They used to be isolated by accident. Each of ~80 classes declared its own byte-identical
+ * {@code @DynamicPropertySource}, and because {@code DynamicPropertiesContextCustomizer} equality
+ * compares the {@code Set<Method>} it was built from, each got its own context cache key — and
+ * {@link TestcontainersPostgresInitializer} hands every context a freshly created database. Once
+ * {@code ai.tessary.config.TestSecretKeyInitializer} collapsed those contexts, the databases
+ * collapsed with them, and only one class in the suite is {@code @Transactional}. This listener is
+ * the isolation that replaces the accident.
+ *
+ * <p>The table list is read from {@code pg_tables} at run time rather than written down, so it
+ * cannot drift away from the Liquibase changelog. Two categories are held back:
+ *
+ * <ul>
+ *   <li>Liquibase's own bookkeeping — truncating {@code databasechangelog} would make the changelog
+ *       look unapplied to anything that inspected it.
+ *   <li>Whatever boot-time seeding wrote. {@code PriceBookImporter} imports the rate books on
+ *       {@code ApplicationReadyEvent}; that runs once per context, so a class that truncated
+ *       {@code model_price} would leave every later class in the same context with no price book.
+ *       The held-back set is measured rather than listed: the first class to use a context reads
+ *       which tables the boot left non-empty, and those are the reference data.
+ * </ul>
+ *
+ * <p>Registered for every context in {@code src/test/resources/META-INF/spring.factories}. A
+ * listener declared there is added to the framework defaults rather than replacing them.
+ */
+public class SchemaCleaningTestExecutionListener implements TestExecutionListener {
+
+    private static final Set<String> LIQUIBASE_TABLES = Set.of("databasechangelog", "databasechangeloglock");
+
+    /** Keyed by the per-context database URL, which {@link TestcontainersPostgresInitializer} makes unique. */
+    private static final Map<String, Set<String>> SEEDED_TABLES = new ConcurrentHashMap<>();
+
+    @Override
+    public void beforeTestClass(TestContext testContext) {
+        // Forces the context to load if it has not already, which is the point: on the first class
+        // to use a context the database still holds exactly what Liquibase and the boot listeners
+        // left, and that is the only moment reference data can be told apart from test rows.
+        ApplicationContext context = testContext.getApplicationContext();
+        DataSource dataSource = dataSourceOf(context);
+        if (dataSource == null) {
+            return;
+        }
+        SEEDED_TABLES.computeIfAbsent(databaseKey(context), key -> readNonEmptyTables(dataSource));
+    }
+
+    @Override
+    public void afterTestClass(TestContext testContext) {
+        ApplicationContext context = testContext.getApplicationContext();
+        DataSource dataSource = dataSourceOf(context);
+        if (dataSource == null) {
+            return;
+        }
+        Set<String> seeded = SEEDED_TABLES.getOrDefault(databaseKey(context), Set.of());
+        List<String> toClear = readAllTables(dataSource).stream()
+                .filter(table -> !LIQUIBASE_TABLES.contains(table))
+                .filter(table -> !seeded.contains(table))
+                .toList();
+        if (toClear.isEmpty()) {
+            return;
+        }
+        String sql = toClear.stream()
+                .map(table -> "\"public\".\"" + table + "\"")
+                .collect(Collectors.joining(", ", "TRUNCATE TABLE ", " RESTART IDENTITY CASCADE"));
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            requireThrowawayContainer(connection);
+            // A shared context keeps its @Scheduled workers ticking between classes, so the ACCESS
+            // EXCLUSIVE locks TRUNCATE takes can collide with one mid-statement. Bound the wait
+            // rather than hang the suite.
+            statement.execute("SET lock_timeout = '30s'");
+            statement.execute(sql);
+        } catch (SQLException e) {
+            throw new IllegalStateException("failed to clean the test schema after " + testContext.getTestClass(), e);
+        }
+    }
+
+    /**
+     * Refuses to truncate anything but the throwaway Testcontainers database.
+     *
+     * <p>Today this cannot fire: {@link TestcontainersPostgresInitializer} overrides
+     * {@code tessary.jdbc-url} for every context, and this listener is registered only on the test
+     * classpath. But that safety is positional, not structural — it holds because of where two
+     * other files sit. Drop the initializer, let a test pin {@code tessary.jdbc-url} at a higher
+     * precedence, or copy this class into a module wired against a real database, and the next
+     * line would empty it. Asserting on the connection's own URL rather than on a property means
+     * the check reads what is actually about to be truncated.
+     */
+    private static void requireThrowawayContainer(Connection connection) throws SQLException {
+        String url = connection.getMetaData().getURL();
+        String expected = TestPostgres.urlPrefix();
+        if (url == null || !url.startsWith(expected)) {
+            throw new IllegalStateException("refusing to TRUNCATE: connected to " + url
+                    + ", which is not the throwaway Testcontainers database at " + expected
+                    + ". This listener empties every non-seed table and must never point anywhere else.");
+        }
+    }
+
+    private static String databaseKey(ApplicationContext context) {
+        String url = context.getEnvironment().getProperty("tessary.jdbc-url");
+        return url == null ? context.getId() : url;
+    }
+
+    private static @Nullable DataSource dataSourceOf(ApplicationContext context) {
+        return context.getBeanNamesForType(DataSource.class).length == 0 ? null : context.getBean(DataSource.class);
+    }
+
+    private static List<String> readAllTables(DataSource dataSource) {
+        List<String> tables = new ArrayList<>();
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement();
+                ResultSet rows =
+                        statement.executeQuery("SELECT tablename FROM pg_tables WHERE schemaname = 'public'")) {
+            while (rows.next()) {
+                tables.add(rows.getString(1));
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("failed to list the test schema's tables", e);
+        }
+        return tables;
+    }
+
+    private static Set<String> readNonEmptyTables(DataSource dataSource) {
+        Set<String> nonEmpty = new LinkedHashSet<>();
+        try (Connection connection = dataSource.getConnection();
+                Statement statement = connection.createStatement()) {
+            for (String table : readAllTables(dataSource)) {
+                if (LIQUIBASE_TABLES.contains(table)) {
+                    continue;
+                }
+                try (ResultSet rows =
+                        statement.executeQuery("SELECT EXISTS (SELECT 1 FROM \"public\".\"" + table + "\")")) {
+                    if (rows.next() && rows.getBoolean(1)) {
+                        nonEmpty.add(table);
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("failed to read the boot-seeded tables", e);
+        }
+        return nonEmpty;
+    }
+}

--- a/backend/app/src/test/java/ai/tessary/git/GitIntegrationServiceTest.java
+++ b/backend/app/src/test/java/ai/tessary/git/GitIntegrationServiceTest.java
@@ -13,16 +13,9 @@ import ai.tessary.testsupport.TenantFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest
 class GitIntegrationServiceTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     GitIntegrationService service;

--- a/backend/app/src/test/java/ai/tessary/ingest/IngestHealthGroupTest.java
+++ b/backend/app/src/test/java/ai/tessary/ingest/IngestHealthGroupTest.java
@@ -18,6 +18,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
@@ -28,13 +29,15 @@ import org.springframework.web.context.WebApplicationContext;
  * public top-level document still renders no component detail.
  */
 @SpringBootTest
+// Own context on purpose: it boots with real auth and a platform staff list, a posture the rest of the suite must not
+// inherit.
+@TestPropertySource(properties = "test.context-group=ingest-health-group")
 class IngestHealthGroupTest {
 
     private static final String STAFF = "staff-984@example.com";
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.auth.cookie-password", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("workos.api-key", () -> "");
         r.add("workos.client-id", () -> "");

--- a/backend/app/src/test/java/ai/tessary/ingest/spool/KafkaSpoolIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/ingest/spool/KafkaSpoolIntegrationTest.java
@@ -33,6 +33,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.redpanda.RedpandaContainer;
@@ -46,6 +47,9 @@ import org.testcontainers.redpanda.RedpandaContainer;
  */
 @Testcontainers
 @SpringBootTest(properties = {"tessary.ingest.substrate.rollup-enabled=false"})
+// Own context on purpose: it swaps the ingest spool onto a Redpanda container, so its bean graph is not the shared
+// one.
+@TestPropertySource(properties = "test.context-group=kafka-spool")
 class KafkaSpoolIntegrationTest {
     private static final Logger log = LoggerFactory.getLogger(KafkaSpoolIntegrationTest.class);
 
@@ -55,7 +59,6 @@ class KafkaSpoolIntegrationTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.ingest.spool.mode", () -> "kafka");
         r.add("tessary.ingest.spool.kafka.bootstrap-servers", REDPANDA::getBootstrapServers);
         r.add("tessary.ingest.spool.kafka.partitions", () -> "4");

--- a/backend/app/src/test/java/ai/tessary/ingest/substrate/SubstrateSourceIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/ingest/substrate/SubstrateSourceIntegrationTest.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance test for the substrate-as-source chain (substrate → {@code sdk} source → run): data ingested
@@ -42,11 +40,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class SubstrateSourceIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SessionRepository sessions;

--- a/backend/app/src/test/java/ai/tessary/ingest/substrate/SubstrateWriteIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/ingest/substrate/SubstrateWriteIntegrationTest.java
@@ -35,8 +35,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Acceptance test for the async substrate write path end to end — {@code enqueue} → sample → redact →
@@ -50,19 +49,18 @@ import org.springframework.test.context.DynamicPropertySource;
  *
  * <p>No grading {@code run} row exists at any point and no LLM call happens — the path is structural
  * only.
+ *
+ * <p>There is deliberately no queue override: the burst below runs at the SHIPPED defaults. It stays far
+ * inside the byte budget (~1%), so it proves the defaults hold a real burst rather than showing where the
+ * budget sheds; {@code SubstrateWriterResilienceTest} covers the byte accounting at the edge.
  */
 @SpringBootTest(properties = {"tessary.ingest.substrate.rollup-enabled=false"})
+// Own context on purpose: it counts JDBC round trips across a full burst, so another class writing spans into the
+// same context would corrupt the measurement.
+@TestPropertySource(properties = "test.context-group=substrate-write")
 class SubstrateWriteIntegrationTest {
 
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(SubstrateWriteIntegrationTest.class);
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-        // No queue override: the burst below runs at the SHIPPED defaults. It is far
-        // inside the byte budget (~1%), so it proves the defaults hold a real burst, not where the budget
-        // sheds; SubstrateWriterResilienceTest covers the byte accounting at the edge.
-    }
 
     @Autowired
     SubstrateWriter writer;

--- a/backend/app/src/test/java/ai/tessary/ingest/substrate/v2/SpanResolverIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/ingest/substrate/v2/SpanResolverIntegrationTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * The two micro-batch resolvers: the ancestry fixpoint (§6.4) and the correlation backfill (§6.3), and the
@@ -48,6 +49,9 @@ import org.springframework.jdbc.core.simple.JdbcClient;
             "tessary.ingest.substrate.rollup-enabled=false",
             "tessary.ingest.substrate.resolver-batch-size=500"
         })
+// Own context on purpose: both resolvers select from a GLOBAL partial index, so another class's spans would consume
+// the batch limit the starvation test exists to measure.
+@TestPropertySource(properties = "test.context-group=span-resolver")
 class SpanResolverIntegrationTest {
 
     @Autowired

--- a/backend/app/src/test/java/ai/tessary/llm/ProjectModelSettingRepositoryTest.java
+++ b/backend/app/src/test/java/ai/tessary/llm/ProjectModelSettingRepositoryTest.java
@@ -12,8 +12,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * {@code project_model_setting} against the real Postgres — the round-trip the mocked
@@ -22,11 +20,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class ProjectModelSettingRepositoryTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantService tenants;

--- a/backend/app/src/test/java/ai/tessary/mcp/McpControllerTest.java
+++ b/backend/app/src/test/java/ai/tessary/mcp/McpControllerTest.java
@@ -67,7 +67,6 @@ class McpControllerTest {
             chains: []
             taxonomy: []
             """);
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         // Enable auth so MCP bearer-token verification runs. Say so directly rather than
         // configuring a fake external-provider key as an indirect toggle -- see
         // TestAuthDisabledInitializer's javadoc for why.

--- a/backend/app/src/test/java/ai/tessary/metering/MeteringIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/metering/MeteringIntegrationTest.java
@@ -57,7 +57,6 @@ class MeteringIntegrationTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.metering.storage-enabled", () -> "true");
     }
 

--- a/backend/app/src/test/java/ai/tessary/onboarding/OnboardingRepositoryTest.java
+++ b/backend/app/src/test/java/ai/tessary/onboarding/OnboardingRepositoryTest.java
@@ -16,8 +16,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Pins the exact invariant {@link OnboardingRepository#trafficWindow} depends on being additive
@@ -29,11 +27,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class OnboardingRepositoryTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     OnboardingRepository onboarding;

--- a/backend/app/src/test/java/ai/tessary/pipeline/CodeFactPersistenceIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/pipeline/CodeFactPersistenceIntegrationTest.java
@@ -21,8 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The code-tracked facts survive a real round-trip through Postgres — parse is only half the contract,
@@ -37,11 +35,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class CodeFactPersistenceIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/backend/app/src/test/java/ai/tessary/pipeline/ImportControllerTest.java
+++ b/backend/app/src/test/java/ai/tessary/pipeline/ImportControllerTest.java
@@ -54,7 +54,6 @@ class ImportControllerTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         // Enable auth so this test exercises the real, authenticated request path -- say so
         // directly rather than configuring a fake external-provider key as an indirect toggle.
         // See TestAuthDisabledInitializer's javadoc.

--- a/backend/app/src/test/java/ai/tessary/pipeline/PipelineRepositoryTest.java
+++ b/backend/app/src/test/java/ai/tessary/pipeline/PipelineRepositoryTest.java
@@ -21,8 +21,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Round-trip every column on the pipeline tables. The bug this guards against:
@@ -31,11 +29,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class PipelineRepositoryTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     PipelineRepository repo;

--- a/backend/app/src/test/java/ai/tessary/plan/CapabilityFlagLayerTest.java
+++ b/backend/app/src/test/java/ai/tessary/plan/CapabilityFlagLayerTest.java
@@ -16,8 +16,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * This build's resolution contract, against real {@code org_feature_flag} rows:
@@ -32,11 +30,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class CapabilityFlagLayerTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     /** What an open build serves before anybody touches it. Mirrors CapabilityService's two private sets. */
     private static final Set<Capability> OFF_BY_DEFAULT = EnumSet.of(

--- a/backend/app/src/test/java/ai/tessary/pricing/ModelResolverIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/pricing/ModelResolverIntegrationTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Resolution precedence, against the imported books rather than an in-memory map. These are the cases the
@@ -17,6 +18,9 @@ import org.springframework.boot.test.context.SpringBootTest;
  * point of asserting them here is that moving the lookup into the database changed none of them.
  */
 @SpringBootTest
+// Own context on purpose: it resolves against the boot-imported books, which a model row written by any other class
+// would change.
+@TestPropertySource(properties = "test.context-group=model-resolver")
 class ModelResolverIntegrationTest {
 
     @Autowired

--- a/backend/app/src/test/java/ai/tessary/pricing/PriceBookImporterIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/pricing/PriceBookImporterIntegrationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Acceptance for the boot-time rate import against the real Postgres. The importer has already run once
@@ -20,6 +21,9 @@ import org.springframework.jdbc.core.simple.JdbcClient;
  * so every test here is really asking what a SECOND boot does.
  */
 @SpringBootTest
+// Own context on purpose: it asserts what a SECOND boot of the importer does, so it must own the price-book tables
+// the first boot seeded.
+@TestPropertySource(properties = "test.context-group=price-book-importer")
 class PriceBookImporterIntegrationTest {
 
     @Autowired

--- a/backend/app/src/test/java/ai/tessary/priors/IntelligenceModeAuditRepositoryTest.java
+++ b/backend/app/src/test/java/ai/tessary/priors/IntelligenceModeAuditRepositoryTest.java
@@ -12,8 +12,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * Verifies the SOC 2 evidence trail against the real Testcontainers Postgres (the schema
@@ -22,12 +21,10 @@ import org.springframework.test.context.DynamicPropertySource;
  * repository directly and confirm the auditor's boot row is present (single-tenant is the default).
  */
 @SpringBootTest
+// Own context on purpose: it asserts the auditor's boot-time evidence row, which is written once per context and
+// nowhere else.
+@TestPropertySource(properties = "test.context-group=intelligence-mode-audit")
 class IntelligenceModeAuditRepositoryTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     IntelligenceModeAuditRepository repo;

--- a/backend/app/src/test/java/ai/tessary/priors/PriorsServiceTest.java
+++ b/backend/app/src/test/java/ai/tessary/priors/PriorsServiceTest.java
@@ -15,8 +15,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * End-to-end governed-priors pipeline against the real Testcontainers Postgres (the schema
@@ -44,14 +43,12 @@ import org.springframework.test.context.DynamicPropertySource;
             "tessary.priors.epsilon=1.0",
             "tessary.priors.sensitivity=1.0"
         })
+// Own context on purpose: it runs with single-tenant off and the cohort thresholds lowered, a posture no other class
+// should see.
+@TestPropertySource(properties = "test.context-group=priors-service")
 class PriorsServiceTest {
 
     private static final String FEATURE = "grader.pass_rate";
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     PriorsService priors;

--- a/backend/app/src/test/java/ai/tessary/query/QueryApiIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/query/QueryApiIntegrationTest.java
@@ -33,8 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance test for the aggregation-first query API: each of {@code count}, {@code timeseries},
@@ -45,11 +43,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class QueryApiIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     QueryController controller;

--- a/backend/app/src/test/java/ai/tessary/query/QueryUsageRollupsTest.java
+++ b/backend/app/src/test/java/ai/tessary/query/QueryUsageRollupsTest.java
@@ -26,8 +26,6 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance: the pre-aggregated {@code metric_rollup} table is reachable through the generic
@@ -40,11 +38,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class QueryUsageRollupsTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     QueryController controller;

--- a/backend/app/src/test/java/ai/tessary/rca/RcaControllerTest.java
+++ b/backend/app/src/test/java/ai/tessary/rca/RcaControllerTest.java
@@ -22,8 +22,6 @@ import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
 /**
@@ -42,17 +40,12 @@ import org.springframework.test.context.TestPropertySource;
 // it (claimBatch's LIMIT 0 returns nothing); the long heartbeat cannot park it alone, because
 // @Scheduled(fixedDelay) has no initial delay and the first tick fires at context startup.
 //
-// Static @TestPropertySource, not the @DynamicPropertySource below: dynamic properties are NOT part
-// of the context cache key, so a parking value registered there would silently not apply whenever
-// another test class built the shared context first.
+// Static @TestPropertySource, not @DynamicPropertySource: a dynamic registration keys the context
+// cache on the declaring Method rather than on the value, which forks a context per class instead of
+// letting this one and RcaWorkerTest share the one parked context they both want.
 @SpringBootTest
 @TestPropertySource(properties = {"tessary.rca.batch-size=0", "tessary.rca.heartbeat-ms=3600000"})
 class RcaControllerTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     RcaController controller;

--- a/backend/app/src/test/java/ai/tessary/rca/RcaWorkerTest.java
+++ b/backend/app/src/test/java/ai/tessary/rca/RcaWorkerTest.java
@@ -45,8 +45,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -73,18 +71,15 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 // unaffected. Lengthening the heartbeat CANNOT do this on its own — @Scheduled(fixedDelay) has no
 // initial delay, so the first tick always fires at context startup, inside the test window.
 //
-// Both properties are static @TestPropertySource, not @DynamicPropertySource, because dynamic
-// properties are NOT part of the context cache key: ~90 other @SpringBootTest classes register only
-// `tessary.secret-key` and share this exact MergedContextConfiguration, so whichever builds the
-// context first wins and a dynamic parking value silently never applies.
+// Both properties are static @TestPropertySource, not @DynamicPropertySource. Dynamic properties DO
+// reach the context cache key -- DynamicPropertiesContextCustomizer.equals compares the Set<Method>
+// it was built from -- but that is exactly the problem: the key would turn on which class declared
+// the method rather than on what it registered, so this class would fork a context of its own for a
+// value @TestPropertySource states in the cache key directly, where two classes wanting the same
+// parking share one context.
 @SpringBootTest
 @TestPropertySource(properties = {"tessary.rca.batch-size=0", "tessary.rca.heartbeat-ms=3600000"})
 class RcaWorkerTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     RcaWorker worker;

--- a/backend/app/src/test/java/ai/tessary/redaction/RedactionGuardIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/redaction/RedactionGuardIntegrationTest.java
@@ -18,8 +18,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance test for the PII redaction write-path guard against the real pgvector Postgres
@@ -29,11 +27,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class RedactionGuardIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     SubstrateWriter writer;

--- a/backend/app/src/test/java/ai/tessary/retention/MediaCollectionIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/retention/MediaCollectionIntegrationTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Media garbage collection: bytes nothing references are reclaimed, and bytes something references are
@@ -36,11 +34,6 @@ class MediaCollectionIntegrationTest {
 
     /** {@link RetentionPinIntegrationTest}'s fingerprint: one context and one database for both, and
      *  sweeps confined to the database whose other tests already expect them. */
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
-
     private static final String OLD = Instant.now().minus(30, ChronoUnit.DAYS).toString();
 
     @Autowired

--- a/backend/app/src/test/java/ai/tessary/retention/ProjectPurgeIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/retention/ProjectPurgeIntegrationTest.java
@@ -16,8 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The background purge, end to end: a marked project's data goes, its neighbour's does not, and the
@@ -31,11 +29,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class ProjectPurgeIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     ProjectPurgeWorker worker;

--- a/backend/app/src/test/java/ai/tessary/retention/RetentionPinIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/retention/RetentionPinIntegrationTest.java
@@ -17,8 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * The retention pin, both directions. Substrate a live claim stands on is never deleted, and substrate
@@ -38,11 +36,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class RetentionPinIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     private static final String AGED = Instant.now().minus(200, ChronoUnit.DAYS).toString();
 

--- a/backend/app/src/test/java/ai/tessary/retention/RetentionSettingsIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/retention/RetentionSettingsIntegrationTest.java
@@ -41,7 +41,6 @@ class RetentionSettingsIntegrationTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.auth.cookie-password", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("workos.api-key", () -> "");
         r.add("workos.client-id", () -> "");

--- a/backend/app/src/test/java/ai/tessary/search/GlobalSearchServiceIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/search/GlobalSearchServiceIntegrationTest.java
@@ -17,8 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -35,11 +33,6 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @SpringBootTest
 class GlobalSearchServiceIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     GlobalSearchService service;

--- a/backend/app/src/test/java/ai/tessary/storage/PostgresMediaStoreTest.java
+++ b/backend/app/src/test/java/ai/tessary/storage/PostgresMediaStoreTest.java
@@ -15,8 +15,6 @@ import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for the {@link MediaStore} SPI against the real pgvector Postgres
@@ -26,11 +24,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class PostgresMediaStoreTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     MediaStore media;

--- a/backend/app/src/test/java/ai/tessary/storage/TraceSubstrateRepositoryTest.java
+++ b/backend/app/src/test/java/ai/tessary/storage/TraceSubstrateRepositoryTest.java
@@ -16,8 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance test for the v2 trace list surface: it is a filter, a sort and a page over columns a
@@ -34,11 +32,6 @@ import org.springframework.test.context.DynamicPropertySource;
             "tessary.ingest.substrate.rollup-enabled=false"
         })
 class TraceSubstrateRepositoryTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantService tenants;

--- a/backend/app/src/test/java/ai/tessary/tenant/ApiKeyManagementTest.java
+++ b/backend/app/src/test/java/ai/tessary/tenant/ApiKeyManagementTest.java
@@ -13,8 +13,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Managed-key lifecycle against the real Postgres (Testcontainers): create → hash → resolve →
@@ -23,11 +21,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class ApiKeyManagementTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantService tenants;

--- a/backend/app/src/test/java/ai/tessary/tenant/ApiKeyScopeEnforcementTest.java
+++ b/backend/app/src/test/java/ai/tessary/tenant/ApiKeyScopeEnforcementTest.java
@@ -14,8 +14,6 @@ import ai.tessary.query.QueryDtos.CountRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance: a key cannot act outside its scope. Drives the write ({@code /v1/traces}) and
@@ -26,12 +24,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class ApiKeyScopeEnforcementTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-        // OTLP HTTP ingest is always on now, so the scope gate (not a disabled-route 404) is what we hit.
-    }
 
     @Autowired
     OtlpTraceController otlp;

--- a/backend/app/src/test/java/ai/tessary/tenant/ApiKeyServiceTest.java
+++ b/backend/app/src/test/java/ai/tessary/tenant/ApiKeyServiceTest.java
@@ -13,8 +13,6 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * MCP-token semantics are security-critical: a bcrypt regression, a missed
@@ -23,11 +21,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class ApiKeyServiceTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantService tenants;

--- a/backend/app/src/test/java/ai/tessary/tenant/OrgCreationBoundaryTest.java
+++ b/backend/app/src/test/java/ai/tessary/tenant/OrgCreationBoundaryTest.java
@@ -58,7 +58,6 @@ class OrgCreationBoundaryTest {
 
     @DynamicPropertySource
     static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("tessary.auth.cookie-password", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
         r.add("workos.api-key", () -> "");
         r.add("workos.client-id", () -> "");

--- a/backend/app/src/test/java/ai/tessary/tenant/ProjectDeleteEndpointTest.java
+++ b/backend/app/src/test/java/ai/tessary/tenant/ProjectDeleteEndpointTest.java
@@ -15,8 +15,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -30,11 +28,6 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @SpringBootTest
 class ProjectDeleteEndpointTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     OrganizationController controller;

--- a/backend/app/src/test/java/ai/tessary/tenant/RbacEnforcementIntegrationTest.java
+++ b/backend/app/src/test/java/ai/tessary/tenant/RbacEnforcementIntegrationTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.web.server.ResponseStatusException;
 
 /**
@@ -29,11 +27,6 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @SpringBootTest
 class RbacEnforcementIntegrationTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     OrganizationController orgController;

--- a/backend/app/src/test/java/ai/tessary/tenant/TenantServiceTest.java
+++ b/backend/app/src/test/java/ai/tessary/tenant/TenantServiceTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * {@link TenantService} owns the user/org/project bootstrap path. Three
@@ -34,11 +32,6 @@ class TenantServiceTest {
 
     /** These tests are about bootstrap atomicity, not the owned-org cap. */
     private static final int UNCAPPED = Integer.MAX_VALUE;
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantService tenants;

--- a/backend/app/src/test/java/ai/tessary/tenant/VerifiedTokenCacheTest.java
+++ b/backend/app/src/test/java/ai/tessary/tenant/VerifiedTokenCacheTest.java
@@ -11,8 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
 
 /**
  * The three properties {@link VerifiedTokenCache} is only worth having if it holds. Each of these was
@@ -23,12 +22,10 @@ import org.springframework.test.context.DynamicPropertySource;
 // The flood test leaves thousands of entries in the singleton cache and the kill-switch test mutates
 // singleton properties, so this class does not hand a polluted context to the next one.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+// Own context on purpose: this class mutates the singleton TokenCacheProperties and floods the shared cache, and its
+// @DirtiesContext would otherwise evict the context most of the suite runs in.
+@TestPropertySource(properties = "test.context-group=verified-token-cache")
 class VerifiedTokenCacheTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     TenantService tenants;

--- a/backend/app/src/test/java/ai/tessary/version/CommitLineageTest.java
+++ b/backend/app/src/test/java/ai/tessary/version/CommitLineageTest.java
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 /**
  * Acceptance for the commit-SHA lineage spine: a substrate grain — session, turn, trace or span —
@@ -34,11 +32,6 @@ import org.springframework.test.context.DynamicPropertySource;
  */
 @SpringBootTest
 class CommitLineageTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     CommitLineageService lineage;

--- a/backend/app/src/test/java/ai/tessary/version/ProjectVersionRepositoryTest.java
+++ b/backend/app/src/test/java/ai/tessary/version/ProjectVersionRepositoryTest.java
@@ -9,16 +9,9 @@ import ai.tessary.testsupport.TenantFixture;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 
 @SpringBootTest
 class ProjectVersionRepositoryTest {
-
-    @DynamicPropertySource
-    static void props(DynamicPropertyRegistry r) {
-        r.add("tessary.secret-key", () -> "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
-    }
 
     @Autowired
     ProjectVersionRepository repo;

--- a/backend/app/src/test/resources/META-INF/spring.factories
+++ b/backend/app/src/test/resources/META-INF/spring.factories
@@ -2,4 +2,12 @@
 # entries from spring.factories). Points the suite at the JVM-singleton pgvector Testcontainers DB.
 org.springframework.context.ApplicationContextInitializer=\
   ai.tessary.db.TestcontainersPostgresInitializer,\
-  ai.tessary.auth.TestAuthDisabledInitializer
+  ai.tessary.auth.TestAuthDisabledInitializer,\
+  ai.tessary.config.TestSecretKeyInitializer
+
+# Runs alongside the framework defaults (a listener declared here is added to, not substituted for,
+# the DEFAULT_TEST_EXECUTION_LISTENER_CLASS_NAMES set). Empties the schema between test classes that
+# share a context, which is the isolation those classes used to get by accident from each having its
+# own context and therefore its own database.
+org.springframework.test.context.TestExecutionListener=\
+  ai.tessary.db.SchemaCleaningTestExecutionListener

--- a/backend/test-support/src/main/java/ai/tessary/db/TestPostgres.java
+++ b/backend/test-support/src/main/java/ai/tessary/db/TestPostgres.java
@@ -50,12 +50,21 @@ public final class TestPostgres {
 
     /** JDBC URL for a database created via {@link #createIsolatedDatabase()}. */
     public static String jdbcUrl(String dbName) {
+        return urlPrefix() + dbName;
+    }
+
+    /**
+     * Everything in a {@link #jdbcUrl(String)} up to and including the final slash, so a caller
+     * about to do something destructive can prove the connection it holds points at this
+     * throwaway container and not at a database someone cares about. The mapped port is assigned
+     * by Docker per run, which is what makes this worth checking rather than assuming.
+     */
+    public static String urlPrefix() {
         return "jdbc:postgresql://"
                 + CONTAINER.getHost()
                 + ":"
                 + CONTAINER.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)
-                + "/"
-                + dbName;
+                + "/";
     }
 
     public static String username() {

--- a/scripts/check-backend.sh
+++ b/scripts/check-backend.sh
@@ -7,6 +7,19 @@
 # Single source of truth for the backend gate: invoked by both the Taskfile (`task backend:check`,
 # and thus `task check`) and CI (.github/workflows/check.yml, via scripts/check.sh). Keep both callers
 # thin wrappers around this script so the local gate and CI can never drift.
+#
+# `-T 2` builds the reactor two modules at a time. The eleven modules fan out into several
+# independent branches, and the per-module work that fills the wall clock (compile, SpotBugs, PMD,
+# Spotless, forbidden-apis) parallelizes cleanly across them. What does NOT parallelize is `app`'s
+# own surefire run: it is one module, so its tests stay serial within it and `app` is the critical
+# path at roughly 3 of the 5 minutes. The win is that the other ten modules' analysis finishes
+# alongside `app` instead of after it, and it is bounded by that: measured 331s serial vs 303s here.
+#
+# The count is 2 rather than `1C` on purpose. 1C (8 threads), 4 and 2 all landed within 17s of each
+# other, which is inside run-to-run noise, so there is nothing to buy by asking for more threads —
+# and the tests drive a Postgres in a CPU-capped container, so leaving cores for the database is
+# worth more than a wider reactor. A fixed count also behaves the same on a 4-vCPU CI runner as it
+# does on an 8-core laptop.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
@@ -24,4 +37,4 @@ if [ "${jmajor:-0}" != 25 ]; then
 fi
 
 cd "$ROOT/backend"
-exec mvn -B verify "$@"
+exec mvn -B -T 2 verify "$@"


### PR DESCRIPTION
Closes #18.

`check.sh` took 15m34s per PR, and 794s of that was `backend/app`'s `mvn verify`. This lands the three fixes that survived measurement. **No gate is removed** — in particular SpotBugs keeps its find-sec-bugs plugin, which is this repo's only security static analysis while CodeQL stays blocked on GHAS.

## What changed

| Commit | | Effect |
|---|---|---|
| `a5cf1a6` | Collapse 80 duplicate Spring contexts | 83 contexts → 32 |
| `af9858b` | `mvn -T 2` | ~10%, see caveat |
| `7ad96fe` | Pinned, checksum-verified Caddy tarball | 41s → ~5s, and reproducible |

Backend `mvn verify` measured 512s → 353s → 303s locally across the three.

### Why the context collapse works

80 test classes each declared a byte-identical method:

```java
@DynamicPropertySource
static void props(DynamicPropertyRegistry r) {
    r.add("tessary.secret-key", () -> "AAAA...=");
}
```

`DynamicPropertiesContextCustomizer.equals()` compares the `Set<Method>` it was built from. 80 declaring classes mean 80 unequal `Method` objects, so 80 distinct context cache keys, so 80 Spring contexts built to satisfy 80 copies of one line.

The repo already had the fix pattern: `spring.factories` globally registers two `ApplicationContextInitializer`s. `TestSecretKeyInitializer` is the third.

### The part that is not a deletion

Those 80 classes were isolated **by accident** — a separate context means a separate cache key, and `TestcontainersPostgresInitializer` creates a fresh database per context. Collapsing the contexts collapses the databases with them, and exactly one class in the suite is `@Transactional`.

`SchemaCleaningTestExecutionListener` replaces that accident with something deliberate. It reads the table list from `pg_tables` at run time so it cannot drift from the changelog, and holds back Liquibase's bookkeeping plus whatever boot-time seeding wrote (measured on the first class to use a context, not hardcoded, so `PriceBookImporter`'s rate books survive).

## Reviewer: please read this first

**The branch is red, and the failures predate it.** Four `KafkaSpoolIntegrationTest` tests fail. I hard-reset to a pristine tree and ran the same class:

```
pristine    4 failures  (lines 116, 135, 160, 223)
this branch 4 failures  (lines 119, 138, 163, 226)
```

Line numbers shifted by exactly 3, confirming the control ran on unmodified source. They also fail in complete isolation, so it is not cross-class contamination from the now-shared database. `enqueue` returns `false`, which is a Redpanda publish being shed rather than an await expiring.

The likely cause is local: measurements were taken with Docker capped at 2 of 8 cores while a full app stack was co-tenant. **This PR's CI run is the clean experiment** — a 4-vCPU Linux runner with native Docker and nothing else on it. If CI is green, they were environmental.

## Other things worth checking

- `SchemaCleaningTestExecutionListener` refuses to run unless the connection points at the throwaway Testcontainers database, asserted against the connection's own URL rather than a property. Today that cannot fire, but today's safety is positional.
- 14 classes keep their own context deliberately, marked `test.context-group` with a line saying what would break if they shared.
- `-T 2` not `-T 1C`: the 303/314/320 spread for 2/1C/4 threads sits inside 22s of noise between two serial runs. **Treat the ~10% as unproven on CI.**
- `.github/toolchain/Dockerfile` is authored but not armed, following the `codeql.yml` precedent. Three blockers documented at the arming site; the serious one is that Testcontainers needs a Docker socket a job container does not get.

## Deliberately not included

- **Maven build cache.** A warm run finished in 4.4s having run zero tests and zero SpotBugs, and logged `Skipping plugin execution (cached): spotbugs:check`. That is an absent gate, not a fast one. Worth revisiting scoped to compile-only.
- **Parallel test execution.** What got built was surefire sharding, which gives each shard its own context cache and undoes this PR's main win. It went slower with 62 failures. The one-JVM design was never actually tested, so it is untried rather than disproven.

## Known follow-ups

- `MetricDriftSweepIntegrationTest` can lose rows to a background `@Scheduled` sweep now that classes share a database. Observed once during measurement, passing since. Not suppressed.
- Unrelated and pre-existing: surefire forks a **Java 26** JVM while `check-backend.sh` only checks the launcher is Java 25, so the gate's JDK guard does not cover the JVM the tests run in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)