### PR TITLE
fix(tests): kill the two races that redden CI at random

### DIFF
--- a/backend/substrate/src/test/java/ai/tessary/ingest/substrate/SubstrateWriterResilienceTest.java
+++ b/backend/substrate/src/test/java/ai/tessary/ingest/substrate/SubstrateWriterResilienceTest.java
@@ -14,6 +14,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -117,10 +118,11 @@ class SubstrateWriterResilienceTest {
     // ---- the byte budget ----
 
     /** A blocking writer, so batches stay queued and the byte accounting can be observed at rest. */
-    private static SpanBatchWriter blockingWriter(CountDownLatch release) {
+    private static SpanBatchWriter blockingWriter(CountDownLatch entered, CountDownLatch release) {
         SpanBatchWriter spans = Mockito.mock(SpanBatchWriter.class);
         try {
             Mockito.when(spans.write(Mockito.anyString(), Mockito.anyList())).thenAnswer(inv -> {
+                entered.countDown();
                 release.await();
                 return 1;
             });
@@ -167,10 +169,11 @@ class SubstrateWriterResilienceTest {
      */
     @Test
     void enqueue_shedsOnTheByteBudget_notTheBatchCount() throws Exception {
+        CountDownLatch entered = new CountDownLatch(1);
         CountDownLatch release = new CountDownLatch(1);
         SubstrateProperties props = new SubstrateProperties();
         props.setQueueMaxBytes(300_000);
-        SubstrateWriter writer = writerWith(props, blockingWriter(release));
+        SubstrateWriter writer = writerWith(props, blockingWriter(entered, release));
         try {
             // ~100 KB each (payload + the fixed per-entry allowance), so two fit under 300 KB and the
             // third does not — with no count bound at all, which is the point.
@@ -178,6 +181,10 @@ class SubstrateWriterResilienceTest {
             assertTrue(writer.enqueue("p1", List.of(sized("b", 100_000))), "second batch fits");
             assertFalse(writer.enqueue("p1", List.of(sized("c", 100_000))), "third exceeds the byte budget");
             assertEquals(1L, writer.shedBatches(), "the refusal must be counted as a shed");
+            // Depth only drops once the drainer has CLAIMED a batch, so wait for it to be inside the
+            // write rather than racing it: the reserved bytes are held until ack, so nothing above
+            // this line depends on the timing.
+            assertTrue(entered.await(10, TimeUnit.SECONDS), "the drainer must have claimed the first batch");
             assertTrue(writer.queueDepth() <= 1, "one batch in flight, one queued: the count was never the bound");
         } finally {
             release.countDown();

--- a/sandbox-runner/launcher/server.js
+++ b/sandbox-runner/launcher/server.js
@@ -1558,9 +1558,11 @@ if (require.main === module && BACKEND === 'docker') {
 if (require.main === module) server.listen(PORT, () => {
   const detail = BACKEND === 'docker' ? `backend=docker, image=${AGENT_IMAGE}, concurrency=${SANDBOX_DOCKER_CONCURRENCY}`
     : BACKEND === 'local' ? 'backend=local' : `backend=e2b, template=${ANALYZER_TEMPLATE}`;
+  // The BOUND port, not the configured one: PORT=0 asks the OS for a free port, and the tests
+  // read the assignment back off this line rather than guessing a port that may be taken.
   // No more deployment-wide provider note — every request's provider now rides on its
   // own `credential.provider`, not a boot-time env var.
-  console.log(`sandbox-runner launcher listening on :${PORT} (${detail})`);
+  console.log(`sandbox-runner launcher listening on :${server.address().port} (${detail})`);
 });
 
 // Test seam only (test/sandbox-posture.test.js): requiring this module never listens or touches Docker.

--- a/sandbox-runner/launcher/test/docker-backend.test.js
+++ b/sandbox-runner/launcher/test/docker-backend.test.js
@@ -124,23 +124,26 @@ function startFakeDaemon(
   });
 }
 
+// PORT=0 hands the choice to the OS and the launcher logs back the port it actually bound, so
+// tests can never collide on a guessed one. Returns that port alongside the child.
 async function startLauncher(env) {
   const child = spawn('node', [SERVER_JS], {
-    env: { ...process.env, ...env },
+    env: { ...process.env, ...env, PORT: '0' },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-  await new Promise((resolve, reject) => {
+  const port = await new Promise((resolve, reject) => {
     let out = '';
     const onData = (d) => {
       out += d.toString();
-      if (/listening on/.test(out)) { child.stdout.off('data', onData); resolve(); }
+      const bound = /listening on :(\d+)/.exec(out);
+      if (bound) { child.stdout.off('data', onData); resolve(Number(bound[1])); }
     };
     child.stdout.on('data', onData);
     child.stderr.on('data', (d) => { out += d.toString(); });
     child.on('exit', (code) => reject(new Error(`launcher exited early (code ${code}): ${out}`)));
     setTimeout(() => reject(new Error(`launcher did not start in time: ${out}`)), 5000);
   });
-  return child;
+  return { child, port };
 }
 
 function postJson(port, urlPath, body, apiKey) {
@@ -171,15 +174,13 @@ test('docker backend: container-create carries the required hardening flags', as
   fs.mkdirSync(workDir, { recursive: true });
 
   const daemon = await startFakeDaemon(socketPath, { waitDelayMs: 20 });
-  const port = 18500 + Math.floor(Math.random() * 500);
-  const child = await startLauncher({
+  const { child, port } = await startLauncher({
     SANDBOX_BACKEND: 'docker',
     DOCKER_SOCKET_PATH: socketPath,
     AGENT_IMAGE: 'test-agent:latest',
     LAUNCHER_WORK_DIR: workDir,
     SANDBOX_WORK_VOLUME: 'test-work-volume', // never created — the fake daemon never mounts it
     SANDBOX_API_KEY: 'testkey',
-    PORT: String(port),
     SANDBOX_DOCKER_CONCURRENCY: '1',
     AWS_REGION: 'us-east-1',
   });
@@ -222,15 +223,13 @@ test('docker backend: SANDBOX_DOCKER_CONCURRENCY=1 serializes two concurrent run
 
   const WAIT_MS = 200;
   const daemon = await startFakeDaemon(socketPath, { waitDelayMs: WAIT_MS });
-  const port = 18500 + Math.floor(Math.random() * 500);
-  const child = await startLauncher({
+  const { child, port } = await startLauncher({
     SANDBOX_BACKEND: 'docker',
     DOCKER_SOCKET_PATH: socketPath,
     AGENT_IMAGE: 'test-agent:latest',
     LAUNCHER_WORK_DIR: workDir,
     SANDBOX_WORK_VOLUME: 'test-work-volume',
     SANDBOX_API_KEY: 'testkey',
-    PORT: String(port),
     SANDBOX_DOCKER_CONCURRENCY: '1',
     AWS_REGION: 'us-east-1',
   });
@@ -267,15 +266,13 @@ test('docker backend: pulls AGENT_IMAGE when the daemon does not already have it
   // comment). The raw Engine API's /containers/create does not auto-pull, so the launcher must
   // pull it itself before create; without that, this request would 404 at create time.
   const daemon = await startFakeDaemon(socketPath, { waitDelayMs: 20, imageMissing: true });
-  const port = 18500 + Math.floor(Math.random() * 500);
-  const child = await startLauncher({
+  const { child, port } = await startLauncher({
     SANDBOX_BACKEND: 'docker',
     DOCKER_SOCKET_PATH: socketPath,
     AGENT_IMAGE: 'test-agent:latest',
     LAUNCHER_WORK_DIR: workDir,
     SANDBOX_WORK_VOLUME: 'test-work-volume',
     SANDBOX_API_KEY: 'testkey',
-    PORT: String(port),
     SANDBOX_DOCKER_CONCURRENCY: '1',
     AWS_REGION: 'us-east-1',
   });
@@ -308,15 +305,13 @@ test('docker backend: is the ACTUAL default when SANDBOX_BACKEND is unset', asyn
   fs.mkdirSync(workDir, { recursive: true });
 
   const daemon = await startFakeDaemon(socketPath, { waitDelayMs: 20 });
-  const port = 18500 + Math.floor(Math.random() * 500);
-  const child = await startLauncher({
+  const { child, port } = await startLauncher({
     // SANDBOX_BACKEND intentionally absent.
     DOCKER_SOCKET_PATH: socketPath,
     AGENT_IMAGE: 'test-agent:latest',
     LAUNCHER_WORK_DIR: workDir,
     SANDBOX_WORK_VOLUME: 'test-work-volume',
     SANDBOX_API_KEY: 'testkey',
-    PORT: String(port),
     SANDBOX_DOCKER_CONCURRENCY: '1',
     AWS_REGION: 'us-east-1',
     // No E2B_API_KEY, no AWS credentials beyond region: the docker default must not need them.
@@ -348,15 +343,13 @@ test('docker backend: two agentic routes share the SAME semaphore under concurre
 
   const WAIT_MS = 200;
   const daemon = await startFakeDaemon(socketPath, { waitDelayMs: WAIT_MS });
-  const port = 18500 + Math.floor(Math.random() * 500);
-  const child = await startLauncher({
+  const { child, port } = await startLauncher({
     SANDBOX_BACKEND: 'docker',
     DOCKER_SOCKET_PATH: socketPath,
     AGENT_IMAGE: 'test-agent:latest',
     LAUNCHER_WORK_DIR: workDir,
     SANDBOX_WORK_VOLUME: 'test-work-volume',
     SANDBOX_API_KEY: 'testkey',
-    PORT: String(port),
     SANDBOX_DOCKER_CONCURRENCY: '1',
     AWS_REGION: 'us-east-1',
   });
@@ -394,15 +387,13 @@ async function runOneAgentJob(env, daemonOpts) {
   const workDir = path.join(scratch, 'work');
   fs.mkdirSync(workDir, { recursive: true });
   const daemon = await startFakeDaemon(socketPath, { waitDelayMs: 10, ...daemonOpts });
-  const port = 19100 + Math.floor(Math.random() * 400);
-  const child = await startLauncher({
+  const { child, port } = await startLauncher({
     SANDBOX_BACKEND: 'docker',
     DOCKER_SOCKET_PATH: socketPath,
     AGENT_IMAGE: 'test-agent:latest',
     LAUNCHER_WORK_DIR: workDir,
     SANDBOX_WORK_VOLUME: 'test-work-volume',
     SANDBOX_API_KEY: 'testkey',
-    PORT: String(port),
     SANDBOX_DOCKER_CONCURRENCY: '1',
     AWS_REGION: 'us-east-1',
     ...env,

--- a/sandbox-runner/launcher/test/e2b-backend.test.js
+++ b/sandbox-runner/launcher/test/e2b-backend.test.js
@@ -27,23 +27,26 @@ const SERVER_JS = path.join(__dirname, '..', 'server.js');
 // docker-backend.test.js's identical constant for why.
 const BEDROCK_CREDENTIAL = { provider: 'BEDROCK', aws_region: 'us-east-1', aws_access_key: 'test-akid', aws_secret_key: 'test-secret' };
 
+// PORT=0 hands the choice to the OS and the launcher logs back the port it actually bound, so
+// tests can never collide on a guessed one. Returns that port alongside the child.
 async function startLauncher(env) {
   const child = spawn('node', [SERVER_JS], {
-    env: { ...process.env, ...env },
+    env: { ...process.env, ...env, PORT: '0' },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
-  await new Promise((resolve, reject) => {
+  const port = await new Promise((resolve, reject) => {
     let out = '';
     const onData = (d) => {
       out += d.toString();
-      if (/listening on/.test(out)) { child.stdout.off('data', onData); resolve(); }
+      const bound = /listening on :(\d+)/.exec(out);
+      if (bound) { child.stdout.off('data', onData); resolve(Number(bound[1])); }
     };
     child.stdout.on('data', onData);
     child.stderr.on('data', (d) => { out += d.toString(); });
     child.on('exit', (code) => reject(new Error(`launcher exited early (code ${code}): ${out}`)));
     setTimeout(() => reject(new Error(`launcher did not start in time: ${out}`)), 5000);
   });
-  return child;
+  return { child, port };
 }
 
 function postJson(port, urlPath, body, apiKey) {
@@ -77,12 +80,10 @@ const LOCALHOST_URLS = [
 
 for (const route of ['/rca', '/triage']) {
   test(`e2b backend: ${route} rejects a localhost mcp.url before creating a sandbox`, async () => {
-    const port = 18500 + Math.floor(Math.random() * 500);
-    const child = await startLauncher({
+    const { child, port } = await startLauncher({
       SANDBOX_BACKEND: 'e2b',
       E2B_API_KEY: 'fake-e2b-key',
       SANDBOX_API_KEY: 'testkey',
-      PORT: String(port),
     });
 
     try {
@@ -98,12 +99,10 @@ for (const route of ['/rca', '/triage']) {
   });
 
   test(`e2b backend: ${route} rejects a missing mcp.url before creating a sandbox`, async () => {
-    const port = 18500 + Math.floor(Math.random() * 500);
-    const child = await startLauncher({
+    const { child, port } = await startLauncher({
       SANDBOX_BACKEND: 'e2b',
       E2B_API_KEY: 'fake-e2b-key',
       SANDBOX_API_KEY: 'testkey',
-      PORT: String(port),
     });
 
     try {
@@ -120,12 +119,10 @@ for (const route of ['/rca', '/triage']) {
 
 for (const rawUrl of LOCALHOST_URLS) {
   test(`e2b backend: rejects ${rawUrl} as a localhost form`, async () => {
-    const port = 18500 + Math.floor(Math.random() * 500);
-    const child = await startLauncher({
+    const { child, port } = await startLauncher({
       SANDBOX_BACKEND: 'e2b',
       E2B_API_KEY: 'fake-e2b-key',
       SANDBOX_API_KEY: 'testkey',
-      PORT: String(port),
     });
 
     try {
@@ -181,15 +178,13 @@ test('docker backend: the SAME localhost mcp.url is accepted unchanged (guard is
   });
   await new Promise((resolve) => server.listen(socketPath, resolve));
 
-  const port = 18500 + Math.floor(Math.random() * 500);
-  const child = await startLauncher({
+  const { child, port } = await startLauncher({
     SANDBOX_BACKEND: 'docker',
     DOCKER_SOCKET_PATH: socketPath,
     AGENT_IMAGE: 'test-agent:latest',
     LAUNCHER_WORK_DIR: workDir,
     SANDBOX_WORK_VOLUME: 'test-work-volume',
     SANDBOX_API_KEY: 'testkey',
-    PORT: String(port),
     SANDBOX_DOCKER_CONCURRENCY: '1',
     AWS_REGION: 'us-east-1',
   });


### PR DESCRIPTION
Both open dependabot PRs ([#2](https://github.com/tessaryai/tessary/pull/2), [#3](https://github.com/tessaryai/tessary/pull/3)) went red on `Check` from the same base commit, in two different places. Neither failure had anything to do with the dependency being bumped. Both are races in the tests themselves, and both have been on main all along.

## The port collision

`sandbox-runner/launcher/test/{e2b,docker}-backend.test.js` each picked a port with `18500 + Math.floor(Math.random() * 500)` and no collision check. About fifteen tests across the two files spawn a launcher, so the birthday odds give roughly a one-in-five chance per run that two pick the same number and the second dies:

```
Error: listen EADDRINUSE: address already in use :::18524
    at Object.<anonymous> (sandbox-runner/launcher/server.js:1558:37)
```

`startLauncher` now starts the launcher with `PORT=0` and reads the OS's assignment back off the launcher's own startup line, returning `{ child, port }`. Ten call sites lose their guess.

That needed one production line: `server.js` logged the *configured* `PORT`, which reads `:0` under an ephemeral bind. It now logs `server.address().port` — identical output for a real configured port, and correct for `PORT=0`. Nothing but these tests parses that line; the two docs that quote its format (`sandbox-runner/README.md`, `scripts/dev.sh`) are unaffected.

## The drainer race

`SubstrateWriterResilienceTest.enqueue_shedsOnTheByteBudget_notTheBatchCount` asserted

```
assertTrue(writer.queueDepth() <= 1, "one batch in flight, one queued: the count was never the bound");
```

with nothing waiting for the drainer to have claimed a batch. `queueDepth()` is `queue.size()`, which only drops once `claim()` has polled, so a loaded runner reads 2 and the test goes red.

`blockingWriter` now takes an `entered` latch it counts down as it enters `write`, and the test awaits that before asserting depth. The three byte-budget assertions above it were never at risk either way: `InProcessSpool` releases a claimed batch's reservation on `ack`, not on `claim`, so a batch parked in a blocked write still holds its bytes and the third batch is refused regardless of timing.

## Verification

| | result |
|---|---|
| `e2b-backend.test.js`, 5 runs | 10/10 pass each |
| `docker-backend.test.js`, 3 runs | 8/8 pass each |
| `scripts/check-sandbox-runner-launcher.sh` | green |
| `SubstrateWriterResilienceTest`, 3 runs | 6/6 pass each |
| substrate module, full suite | 230/230 (CI saw 229/230) |
| `mvn -pl substrate spotless:check` | clean |

The full `task check` was not run locally — the remaining backend slices need Docker. CI covers it here.

## For a reviewer

- The `server.js` change is the only production line touched, and it is a log string.
- After this lands, rebasing the two dependabot PRs should turn them green. [#2](https://github.com/tessaryai/tessary/pull/2) separately still needs its undici pin synced: it moves `agent-sandbox/package.json` to `^6.28.1` while `template.ts:113` and `Dockerfile:141` stay `^6.28.0`, which breaks the byte-identity those files document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)