### PR TITLE
fix(config): let a registry install turn the heartbeat off, and drop the empty frontend env template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,8 +23,6 @@
 # env_file, because including one would ship the PUBLISHER's .env to everyone. Those need a small
 # override file instead; docs/self-hosting/setup.mdx's "Operating a stack you started from a
 # registry" has the recipe.
-#
-# Frontend (Vite) build-time vars are a separate file: frontend/.env.example.
 
 # ============================================================================
 # The three keys to set before this instance holds anything real

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -251,21 +251,21 @@ services:
       # without it; there is no fallback endpoint.
       TESSARY_OBSERVER_ENCODER_URL: ${TESSARY_OBSERVER_ENCODER_URL:-}
       TESSARY_OBSERVER_ENCODER_API_KEY: ${TESSARY_OBSERVER_ENCODER_API_KEY:-}
-      # How long the instance keeps traces and detections; 0 keeps forever. Interpolated
-      # here rather than left to env_file so the registry install, which carries no .env, still
-      # reads the operator's .env beside the command (rule 3 in the header).
       # The ingest spool: `memory` (default, no broker) or `kafka`, the opt-in durable buffer
       # served by the `redpanda` service below under `--profile kafka`. Nothing depends_on it on
       # purpose: with the mode left at memory the profile never starts, and with it set to kafka a
       # broker that is still coming up simply sheds (503 + Retry-After) until it answers.
       TESSARY_INGEST_SPOOL_MODE: ${TESSARY_INGEST_SPOOL_MODE:-memory}
       TESSARY_INGEST_SPOOL_KAFKA_BOOTSTRAP_SERVERS: ${TESSARY_INGEST_SPOOL_KAFKA_BOOTSTRAP_SERVERS:-redpanda:9092}
+      # The sweep, and how long the instance keeps traces and detections; 0 keeps forever.
+      # Interpolated here rather than left to env_file so the registry install, which carries no
+      # .env, still reads the operator's .env beside the command (rule 3 in the header).
       TESSARY_RETENTION_ENABLED: ${TESSARY_RETENTION_ENABLED:-true}
       TESSARY_RETENTION_TRACE_TTL_DAYS: ${TESSARY_RETENTION_TRACE_TTL_DAYS:-90}
       TESSARY_RETENTION_DETECTION_TTL_DAYS: ${TESSARY_RETENTION_DETECTION_TTL_DAYS:-90}
-      # The opt-OUT heartbeat. Interpolated for the same reason as the two keys above, and it
-      # matters more here: left to env_file alone, an operator on the registry install who sets
-      # this to false in their .env gets no error and keeps sending the ping.
+      # The opt-OUT heartbeat, interpolated for that same reason, and it matters more here: left
+      # to env_file alone, an operator on the registry install who sets this to false in their
+      # .env gets no error and keeps sending the ping.
       TESSARY_TELEMETRY_ENABLED: ${TESSARY_TELEMETRY_ENABLED:-true}
     depends_on:
       postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,6 +263,10 @@ services:
       TESSARY_RETENTION_ENABLED: ${TESSARY_RETENTION_ENABLED:-true}
       TESSARY_RETENTION_TRACE_TTL_DAYS: ${TESSARY_RETENTION_TRACE_TTL_DAYS:-90}
       TESSARY_RETENTION_DETECTION_TTL_DAYS: ${TESSARY_RETENTION_DETECTION_TTL_DAYS:-90}
+      # The opt-OUT heartbeat. Interpolated for the same reason as the two keys above, and it
+      # matters more here: left to env_file alone, an operator on the registry install who sets
+      # this to false in their .env gets no error and keeps sending the ping.
+      TESSARY_TELEMETRY_ENABLED: ${TESSARY_TELEMETRY_ENABLED:-true}
     depends_on:
       postgres:
         condition: service_healthy

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,0 @@
-# Frontend (Vite) environment. Copy to `.env.local` and uncomment to override.
-# Only VITE_-prefixed vars are exposed to the browser bundle.

--- a/scripts/lib/export-denylist.txt
+++ b/scripts/lib/export-denylist.txt
@@ -57,4 +57,3 @@ tessary-paid|delete|dir|paid overlay
 *.key|never|glob|key material
 id_rsa*|never|glob|key material
 .env.example|exempt|file|documented template, no values
-frontend/.env.example|exempt|file|documented template, no values

--- a/scripts/lib/export-manifest-baseline.txt
+++ b/scripts/lib/export-manifest-baseline.txt
@@ -1241,7 +1241,6 @@ docs/vale/styles/Tessary/TitleCaseH1.yml
 docs/vale/styles/Tessary/VaguePrerequisites.yml
 docs/vale/styles/Tessary/WordsToAvoid.yml
 frontend/.dockerignore
-frontend/.env.example
 frontend/.gitignore
 frontend/AGENTS.md
 frontend/DESIGN_SYSTEM.md


### PR DESCRIPTION
Two findings from an audit of the environment-variable surface across the compose files, `.env.example`, the self-hosting docs, `config-keys.md`, and the five consumers (backend Spring properties, sandbox-runner, classify-service, Alloy, scripts).

The audit came back clean otherwise: all 34 keys documented in `configuration.mdx` have a real consumer, the `EVALS_*` names are the rename table in `upgrading.mdx` rather than leftovers, the seven `TESSARY_SANDBOX_*` / `TESSARY_SYNTH_*` / `TESSARY_GRADING_*` keys are correctly parked under "Removed configuration", and the vars with no in-repo consumer (`BACKGROUND_NUM_WORKERS`, `HOST_BIND`, `ARGILLA_USERNAME`/`_PASSWORD`, `BENCH_JFR_SETTINGS`) are all consumed by third-party images or Compose itself.

## `TESSARY_TELEMETRY_ENABLED` could not be turned off on a registry install

It was the only key in `.env.example` that `docker-compose.yml` did not name as a `${VAR}`:

```
in .env.example but NOT a ${VAR} in docker-compose.yml:
  TESSARY_TELEMETRY_ENABLED
```

From a clone it reached the backend via `env_file: ./.env`. For the one-command install it did not: `env_file:` is inert there, as rule 3 in the compose header spells out, so the key was passthrough-only. An operator who set `TESSARY_TELEMETRY_ENABLED=false` in their `.env` got no error and kept sending the heartbeat. Silence is the wrong failure mode for an opt-out, and `configuration.mdx` promises this key buys "zero outbound calls".

The two retention keys immediately above it already carry a comment explaining exactly this hazard, so this looks like an omission rather than a decision. Interpolating it also makes `.env.example:21` true again ("a `.env` ... sets every key `docker-compose.yml` names as a `${VAR}` — which is every key in this file"), so no doc change is needed.

`scripts/check-required-inputs.sh` does not catch this: its class (iv) only fires on empty-valued keys, and this one ships `true`.

## `frontend/.env.example` was an empty template for a mechanism nothing uses

The file declared zero variables, and the frontend consumes no environment variable at all: no `import.meta.env`, no `envPrefix`/`loadEnv`/`define` in `vite.config.ts`, and `VITE_` appeared exactly once in the whole tracked tree — inside that file, describing a convention no code follows. It instructed the reader to "uncomment to override" with nothing to uncomment. Removed, along with the pointer at `.env.example:27` and its entries in `export-denylist.txt` and `export-manifest-baseline.txt`.

## Checks

Green: `check-required-inputs`, `check-compose-artifact`, `check-namespaces`, `check-version-consistency`, `check-export-denylist`, `check-open-boundary`, `check-license-headers`, `check-docs-links`.

## Noted, not changed here

- The comment at `docker-compose.yml:138-141` says publishing 4317 "additionally needs `EXPOSE 4317` in `backend/Dockerfile`". That is stale — it is already there at `backend/Dockerfile:112`.
- Six documented keys look like doc rows worth dropping without touching the knob behind them (relaxed binding keeps them settable either way), and three look like fields worth deleting outright. Left for a separate change, since the latter would affect deployments that set them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWhzhsBiesgJbhUuKWxCg1