### PR TITLE
Add issue templates for agent filers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug report
+description: Something isn't working the way it should
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: >
+        Agent filing this: state the observed behavior as fact (command run, output, error text
+        or stack trace verbatim), then the expected behavior. Cite the file and line if you
+        traced it. No hedging or speculation here — put inference in the report body if needed.
+      placeholder: |
+        Ran: task check -- backend
+        Output: <exact error/output>
+        Expected: <what should have happened>
+        Traced to: backend/foo/Bar.java:42
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: >
+        Exact commands, in order, from a clean checkout. Another agent should be able to paste
+        these and hit the same failure with no guessing.
+      placeholder: |
+        1. <command>
+        2. <command>
+        3. <observed failure>
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Commit
+      description: Output of `git rev-parse HEAD` at the time you observed this.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Propose something new or a change to existing behavior
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: >
+        Agent filing this: name the concrete task that's currently blocked or awkward, and point
+        to where in the repo the gap is (file, module, or missing command). Not a vague pain
+        point — something the next agent can verify by looking.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: >
+        The specific change: what gets added or modified, and roughly where. If you considered
+        and rejected an alternative, say so in one line here rather than leaving it implicit.
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` as GitHub issue forms
- Field descriptions address an agent filer, not a person: ask for verbatim command output, file:line citations, and exact reproducible commands instead of prose
- Keeps `blank_issues_enabled: true` via `config.yml`

## Test plan
- [ ] Confirm the forms render correctly under the repo's "New issue" picker on GitHub