### PR TITLE
feat(git): make an access token the default way to connect a repository

### DIFF
--- a/backend/analysis/src/main/java/ai/tessary/rca/AgenticRcaEngine.java
+++ b/backend/analysis/src/main/java/ai/tessary/rca/AgenticRcaEngine.java
@@ -97,7 +97,10 @@ public class AgenticRcaEngine {
             String summary,
             List<Hypothesis> hypotheses,
             List<ChecklistAssessment> checklist,
-            String detailedReport) {}
+            String detailedReport,
+            /** Whether this run actually had the repo to read. Recorded per report, because the
+             *  ceiling belongs to the run, not to whether a repo is connected when someone reads it. */
+            boolean repoAvailable) {}
 
     private final RcaProperties props;
     private final Map<String, RcaSandbox> sandboxes;
@@ -240,7 +243,13 @@ public class AgenticRcaEngine {
                 // The downgrade must be visible where the engineer reads, not only in a log line.
                 detailed = parsed.verdictNote() + "\n\n" + detailed;
             }
-            return new Result(parsed.verdict(), parsed.summary(), parsed.hypotheses(), parsed.checklist(), detailed);
+            return new Result(
+                    parsed.verdict(),
+                    parsed.summary(),
+                    parsed.hypotheses(),
+                    parsed.checklist(),
+                    detailed,
+                    clone.isPresent());
         } finally {
             revokeQuietly(issued.token().id(), keyPrincipal, job);
         }

--- a/backend/analysis/src/main/java/ai/tessary/rca/RcaAnalysisService.java
+++ b/backend/analysis/src/main/java/ai/tessary/rca/RcaAnalysisService.java
@@ -124,7 +124,8 @@ public class RcaAnalysisService {
                 result.summary(),
                 merge(measurements, result.checklist()),
                 result.hypotheses(),
-                result.detailedReport());
+                result.detailedReport(),
+                result.repoAvailable());
     }
 
     /**
@@ -207,8 +208,17 @@ public class RcaAnalysisService {
             String summary,
             List<RuledOutCheck> checks,
             List<Hypothesis> hypotheses,
-            @Nullable String detailedReport) {
-        reports.complete(job.id(), "done", verdict, summary, writeJson(checks), writeJson(hypotheses), detailedReport);
+            @Nullable String detailedReport,
+            boolean repoAvailable) {
+        reports.complete(
+                job.id(),
+                "done",
+                verdict,
+                summary,
+                writeJson(checks),
+                writeJson(hypotheses),
+                detailedReport,
+                repoAvailable);
         log.info(
                 "rca done project={} subject={}:{} metric={} verdict={} hypotheses={}",
                 job.projectId(),

--- a/backend/analysis/src/main/java/ai/tessary/rca/RcaDtos.java
+++ b/backend/analysis/src/main/java/ai/tessary/rca/RcaDtos.java
@@ -96,6 +96,8 @@ public final class RcaDtos {
             List<Hypothesis> hypotheses,
             @JsonProperty("detailed_report") @Nullable String detailedReport,
             String engine,
+            /** Null on reports written before the column existed: unknown, not "no repository". */
+            @JsonProperty("repo_available") @Nullable Boolean repoAvailable,
             @JsonProperty("created_at") String createdAt,
             @JsonProperty("completed_at") @Nullable String completedAt) {
 
@@ -121,6 +123,7 @@ public final class RcaDtos {
                     readList(mapper, r.hypotheses(), new TypeReference<List<Hypothesis>>() {}),
                     r.detailedReport(),
                     r.engine(),
+                    r.repoAvailable(),
                     r.createdAt(),
                     r.completedAt());
         }

--- a/backend/analysis/src/main/java/ai/tessary/rca/RcaReportRepository.java
+++ b/backend/analysis/src/main/java/ai/tessary/rca/RcaReportRepository.java
@@ -25,7 +25,8 @@ public class RcaReportRepository {
     private static final String COLS = "r.id, r.project_id, r.job_id, r.subject_kind, r.subject_id, "
             + "r.subject_label, r.call_site_id, r.metric, r.window_from, r.window_split, r.window_to, "
             + "r.current_value, r.prior_value, r.delta, j.status AS status, r.verdict, r.summary, "
-            + "r.ruled_out, r.hypotheses, r.detailed_report, r.engine, r.created_at, r.completed_at";
+            + "r.ruled_out, r.hypotheses, r.detailed_report, r.engine, r.repo_available, "
+            + "r.created_at, r.completed_at";
 
     private static final String FROM = "FROM rca_report r JOIN job j ON j.id = r.job_id";
 
@@ -200,11 +201,13 @@ public class RcaReportRepository {
             @Nullable String summary,
             @Nullable String ruledOutJson,
             @Nullable String hypothesesJson,
-            @Nullable String detailedReport) {
+            @Nullable String detailedReport,
+            @Nullable Boolean repoAvailable) {
         jdbc.sql("""
                 UPDATE rca_report SET status = :status, verdict = :verdict, summary = :summary,
                     ruled_out = :ruledOut::jsonb, hypotheses = :hypotheses::jsonb,
-                    detailed_report = :detailedReport, completed_at = :now
+                    detailed_report = :detailedReport, repo_available = :repoAvailable,
+                    completed_at = :now
                 WHERE job_id = :jobId
                 """)
                 .param("status", status)
@@ -213,9 +216,17 @@ public class RcaReportRepository {
                 .param("ruledOut", ruledOutJson)
                 .param("hypotheses", hypothesesJson)
                 .param("detailedReport", detailedReport)
+                .param("repoAvailable", repoAvailable)
                 .param("now", Instant.now().toString())
                 .param("jobId", jobId)
                 .update();
+    }
+
+    /** {@code getBoolean} reads SQL NULL as false, which is the one answer this column must not
+     *  invent: a report written before the column existed does not know whether it had a repo. */
+    private static @Nullable Boolean readNullableBoolean(ResultSet rs, String column) throws SQLException {
+        boolean value = rs.getBoolean(column);
+        return rs.wasNull() ? null : value;
     }
 
     private static RcaReportRow map(ResultSet rs) throws SQLException {
@@ -241,6 +252,7 @@ public class RcaReportRepository {
                 rs.getString("hypotheses"),
                 rs.getString("detailed_report"),
                 rs.getString("engine"),
+                readNullableBoolean(rs, "repo_available"),
                 rs.getString("created_at"),
                 rs.getString("completed_at"));
     }

--- a/backend/analysis/src/main/java/ai/tessary/rca/RcaReportRow.java
+++ b/backend/analysis/src/main/java/ai/tessary/rca/RcaReportRow.java
@@ -35,6 +35,7 @@ public record RcaReportRow(
         @Nullable String hypotheses,
         @Nullable String detailedReport,
         String engine,
+        @Nullable Boolean repoAvailable,
         String createdAt,
         @Nullable String completedAt) {
 

--- a/backend/analysis/src/main/java/ai/tessary/rca/RcaWorker.java
+++ b/backend/analysis/src/main/java/ai/tessary/rca/RcaWorker.java
@@ -125,7 +125,7 @@ public class RcaWorker {
             log.debug("rca job failed job={} detail", job.id(), e);
             jobs.markFailed(job.id(), e.getMessage(), props.getMaxAttempts());
             try {
-                reports.complete(job.id(), RcaJobRow.FAILED, null, e.getMessage(), null, null, null);
+                reports.complete(job.id(), RcaJobRow.FAILED, null, e.getMessage(), null, null, null, null);
             } catch (RuntimeException stampFailure) {
                 log.warn(Markers.OPS, "rca failed-report stamp failed job={}: {}", job.id(), stampFailure.getMessage());
             }

--- a/backend/analysis/src/test/java/ai/tessary/rca/AgenticRcaPromptTest.java
+++ b/backend/analysis/src/test/java/ai/tessary/rca/AgenticRcaPromptTest.java
@@ -162,6 +162,7 @@ class AgenticRcaPromptTest {
                 null,
                 null,
                 RcaReportRow.Engine.AGENTIC,
+                null,
                 "2026-05-08T01:00:00Z",
                 null);
     }

--- a/backend/app/src/test/java/ai/tessary/cases/CaseServiceTest.java
+++ b/backend/app/src/test/java/ai/tessary/cases/CaseServiceTest.java
@@ -259,7 +259,8 @@ class CaseServiceTest {
                 "The judge model changed mid-window.",
                 null,
                 null,
-                "## Why\nThe provider rotated the default.");
+                "## Why\nThe provider rotated the default.",
+                true);
         // The wire status is the JOB's, so the queue is what has to say "finished" — the report's own column
         // alone would leave an exhaustion-swept job reading as claimed forever.
         rcaJobs.markDone(jobId);

--- a/backend/app/src/test/java/ai/tessary/git/GitIntegrationServiceTest.java
+++ b/backend/app/src/test/java/ai/tessary/git/GitIntegrationServiceTest.java
@@ -6,10 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import ai.tessary.crypto.SecretBox;
 import ai.tessary.git.GitIntegrationDtos.ConnectRequest;
+import ai.tessary.open.errors.GitError;
 import ai.tessary.open.errors.TessaryException;
 import ai.tessary.tenant.TenantService;
 import ai.tessary.testsupport.TenantFixture;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -22,6 +26,21 @@ class GitIntegrationServiceTest {
 
     @Autowired
     TenantService tenants;
+
+    @Autowired
+    GitIntegrationRepository repo;
+
+    @Autowired
+    SecretBox secretBox;
+
+    @Autowired
+    ObjectMapper mapper;
+
+    /** A service whose one provider answers however this test needs it to. */
+    private GitIntegrationService withProvider(GitProviderClient client) {
+        return new GitIntegrationService(
+                repo, secretBox, mapper, new GitProviderFactory(List.of(client), List.of(), List.of()));
+    }
 
     private ConnectRequest github() {
         return new ConnectRequest("github", "tessary", "tessary", null, "main", 4242L, null);
@@ -56,5 +75,98 @@ class GitIntegrationServiceTest {
         service.connect(pid, github());
         assertTrue(service.delete(pid));
         assertTrue(service.find(pid).isEmpty());
+    }
+
+    // ---- connectVerified: nothing is stored unless the provider confirms the read -------------
+
+    /** A provider that answers verifyAccess and refuses everything else. */
+    private record StubClient(GitProviderClient.RepoAccess access, RuntimeException failure)
+            implements GitProviderClient {
+        @Override
+        public GitProvider provider() {
+            return GitProvider.GITHUB;
+        }
+
+        @Override
+        public GitProviderClient.RepoAccess verifyAccess(GitIntegrationRow integ) {
+            if (failure != null) throw failure;
+            return access;
+        }
+
+        @Override
+        public String resolveHeadSha(GitIntegrationRow integ, String branch) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public CommitComparison compare(GitIntegrationRow integ, String baseSha, String headSha) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isAncestor(GitIntegrationRow integ, String ancestorSha, String descendantSha) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<RepoFile> getTreeFiles(GitIntegrationRow integ, String sha, String pathPrefix) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ChangeRequest openChangeRequest(GitIntegrationRow integ, ChangeRequestSpec spec) {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static ConnectRequest pat(String branch) {
+        return new ConnectRequest("github", "acme", "web", null, branch, null, "github_pat_example");
+    }
+
+    @Test
+    void connectVerified_takesTheDefaultBranchFromTheProviderWhenNoneWasGiven() {
+        String pid =
+                TenantFixture.bootstrap(tenants, "git-verify-branch").project().id();
+        GitIntegrationService svc = withProvider(new StubClient(new GitProviderClient.RepoAccess("trunk"), null));
+
+        GitIntegrationRow row = svc.connectVerified(pid, pat(null));
+
+        // "main" was a guess. The repo's real default branch is what RCA has to check out.
+        assertEquals("trunk", row.defaultBranch());
+        assertEquals("trunk", svc.require(pid).defaultBranch());
+    }
+
+    @Test
+    void connectVerified_keepsAnExplicitBranchOverTheProviderDefault() {
+        String pid = TenantFixture.bootstrap(tenants, "git-verify-explicit")
+                .project()
+                .id();
+        GitIntegrationService svc = withProvider(new StubClient(new GitProviderClient.RepoAccess("trunk"), null));
+
+        assertEquals("release", svc.connectVerified(pid, pat("release")).defaultBranch());
+    }
+
+    @Test
+    void connectVerified_storesNothingWhenTheProviderRefuses() {
+        String pid =
+                TenantFixture.bootstrap(tenants, "git-verify-refused").project().id();
+        GitIntegrationService svc =
+                withProvider(new StubClient(null, new TessaryException(GitError.REPO_UNREACHABLE, "acme/web")));
+
+        TessaryException e = assertThrows(TessaryException.class, () -> svc.connectVerified(pid, pat(null)));
+        assertEquals(GitError.REPO_UNREACHABLE, e.error());
+        // The whole point: a credential that cannot read the repo must not look connected, because
+        // the next thing that notices is an RCA quietly ruling on traces alone.
+        assertTrue(svc.find(pid).isEmpty(), "a refused connect leaves the project unbound");
+    }
+
+    @Test
+    void connect_doesNotAskTheProvider_theInstallCallbackAlreadyProvedTheRepo() {
+        String pid =
+                TenantFixture.bootstrap(tenants, "git-verify-skip").project().id();
+        GitIntegrationService svc =
+                withProvider(new StubClient(null, new IllegalStateException("verifyAccess must not be called here")));
+
+        assertEquals("acme", svc.connect(pid, pat("main")).repoOwner());
     }
 }

--- a/backend/app/src/test/java/ai/tessary/rca/RcaWorkerTest.java
+++ b/backend/app/src/test/java/ai/tessary/rca/RcaWorkerTest.java
@@ -193,7 +193,8 @@ class RcaWorkerTest {
                         List.of(new Hypothesis("stricter prompt", "high", "because", List.of(failingTrace))),
                         List.of(new ChecklistAssessment(
                                 "serving_model", "explains", "commit abc123 moved the call site to a new model")),
-                        "## Investigation"));
+                        "## Investigation",
+                        true));
 
         RcaJobRow job = enqueue(pid, seedFinding(pid, List.of(passingTrace), List.of(failingTrace)));
         worker.runForTest(job);
@@ -316,7 +317,7 @@ class RcaWorkerTest {
 
     private void stubEngine(String verdict, List<ChecklistAssessment> checklist) {
         when(engine.run(any(), any(), anyString(), anyMap(), anySet(), anySet(), anySet()))
-                .thenReturn(new AgenticRcaEngine.Result(verdict, "summary", List.of(), checklist, "## report"));
+                .thenReturn(new AgenticRcaEngine.Result(verdict, "summary", List.of(), checklist, "## report", true));
     }
 
     /** The persisted checklist, by check id. */

--- a/backend/contract/src/main/resources/openapi/tessary-api.json
+++ b/backend/contract/src/main/resources/openapi/tessary-api.json
@@ -6884,6 +6884,12 @@
             "format" : "double",
             "type" : "number"
           },
+          "repo_available" : {
+            "type" : [
+              "boolean",
+              "null"
+            ]
+          },
           "ruled_out" : {
             "items" : {
               "$ref" : "#/components/schemas/RuledOutCheck"
@@ -6937,6 +6943,7 @@
           "job_id",
           "metric",
           "prior_value",
+          "repo_available",
           "ruled_out",
           "status",
           "subject_id",

--- a/backend/core/src/main/resources/db/changelog/changes/0024-rca-report-repo-available.sql
+++ b/backend/core/src/main/resources/db/changelog/changes/0024-rca-report-repo-available.sql
@@ -1,0 +1,16 @@
+--liquibase formatted sql
+
+--changeset evals:0024-rca-report-repo-available
+-- Whether the run actually had the project's repository to read.
+--
+-- An RCA without a repo still produces a report; it just cannot say what changed in the code, and
+-- until now the only trace of that ceiling was a sentence the agent wrote into the markdown body,
+-- where it reads as part of the analysis rather than as a limit on it. The report page needs to say
+-- so above the verdict, and that claim has to be about the run that happened, not about whether a
+-- repo happens to be connected when someone opens the page later.
+--
+-- Nullable on purpose: reports written before this column cannot answer, and "unknown" must not
+-- render as "no repository". Readers show the notice only on an explicit false.
+ALTER TABLE rca_report ADD COLUMN repo_available boolean;
+
+--rollback ALTER TABLE rca_report DROP COLUMN repo_available;

--- a/backend/core/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/core/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -21,3 +21,6 @@ databaseChangeLog:
   - include:
       file: db/changelog/changes/0000-baseline.sql
       relativeToChangelogFile: false
+  - include:
+      file: db/changelog/changes/0024-rca-report-repo-available.sql
+      relativeToChangelogFile: false

--- a/backend/shared/src/main/java/ai/tessary/open/errors/GitError.java
+++ b/backend/shared/src/main/java/ai/tessary/open/errors/GitError.java
@@ -15,6 +15,30 @@ public enum GitError implements ErrorCode {
     TOKEN_MINT_FAILED(HttpStatus.BAD_GATEWAY, "Could not mint a %s access token"),
     PROVIDER_CALL_FAILED(HttpStatus.BAD_GATEWAY, "%s API call failed: %s"),
     MISSING_APP_CONFIG(HttpStatus.FAILED_DEPENDENCY, "Git provider %s is not configured on this server"),
+    /**
+     * The deployment has no {@code TESSARY_SECRET_KEY}, so no credential can be sealed at rest.
+     * Distinct from {@link #MISSING_APP_CONFIG}: a personal access token needs no App, and telling
+     * someone to configure an App is the one instruction that cannot fix this.
+     */
+    SECRET_KEY_MISSING(
+            HttpStatus.FAILED_DEPENDENCY,
+            "This deployment has no encryption key configured, so Tessary cannot store an access token."
+                    + " Set TESSARY_SECRET_KEY on the deployment and restart it"),
+    CREDENTIALS_REJECTED(
+            HttpStatus.BAD_REQUEST, "%s rejected these credentials. Check the token has not expired or been revoked"),
+    /**
+     * GitHub answers 404 both for a repo that does not exist and for a private one the credential
+     * cannot see, and does not say which. The message has to carry both readings rather than assert
+     * the wrong one.
+     */
+    REPO_UNREACHABLE(
+            HttpStatus.BAD_REQUEST,
+            "No repository at %s that these credentials can read. Check the owner and repository name,"
+                    + " and that the token grants Contents: read on it"),
+    REPO_ACCESS_DENIED(
+            HttpStatus.BAD_REQUEST,
+            "These credentials cannot read %s. Grant the token Contents: read on this repository,"
+                    + " or enter a repository it already covers"),
     INSTALL_STATE_INVALID(HttpStatus.BAD_REQUEST, "GitHub install state is invalid or expired"),
     NO_INSTALLED_REPOS(HttpStatus.BAD_REQUEST, "The GitHub App installation grants no repositories"),
     NO_ADMIN_INSTALLATIONS(

--- a/backend/substrate/src/main/java/ai/tessary/git/GitIntegrationController.java
+++ b/backend/substrate/src/main/java/ai/tessary/git/GitIntegrationController.java
@@ -48,7 +48,7 @@ public class GitIntegrationController {
             @Valid @RequestBody ConnectRequest req) {
         Resolved r = requireOwner(ctx, orgSlug, projectSlug);
         return ApiResponse.ok(
-                GitIntegrationView.from(service.connect(r.project().id(), req)));
+                GitIntegrationView.from(service.connectVerified(r.project().id(), req)));
     }
 
     @DeleteMapping

--- a/backend/substrate/src/main/java/ai/tessary/git/GitIntegrationService.java
+++ b/backend/substrate/src/main/java/ai/tessary/git/GitIntegrationService.java
@@ -3,6 +3,7 @@ package ai.tessary.git;
 
 import ai.tessary.crypto.SecretBox;
 import ai.tessary.git.GitIntegrationDtos.ConnectRequest;
+import ai.tessary.git.GitProviderClient.RepoAccess;
 import ai.tessary.open.errors.GitError;
 import ai.tessary.open.errors.TessaryException;
 import ai.tessary.open.obs.Markers;
@@ -24,11 +25,14 @@ public class GitIntegrationService {
     private final GitIntegrationRepository repo;
     private final SecretBox secretBox;
     private final ObjectMapper mapper;
+    private final GitProviderFactory providers;
 
-    public GitIntegrationService(GitIntegrationRepository repo, SecretBox secretBox, ObjectMapper mapper) {
+    public GitIntegrationService(
+            GitIntegrationRepository repo, SecretBox secretBox, ObjectMapper mapper, GitProviderFactory providers) {
         this.repo = repo;
         this.secretBox = secretBox;
         this.mapper = mapper;
+        this.providers = providers;
     }
 
     public Optional<GitIntegrationRow> find(String projectId) {
@@ -41,7 +45,37 @@ public class GitIntegrationService {
                 .orElseThrow(() -> new TessaryException(GitError.INTEGRATION_NOT_FOUND, projectId));
     }
 
+    /**
+     * Bind a repo whose reachability is already established by the flow that got here: the GitHub
+     * App install and reuse callbacks, which enumerated the repo off an installation the authorizing
+     * user was proved to administer. Stores without asking the provider anything.
+     */
     public GitIntegrationRow connect(String projectId, ConnectRequest req) {
+        return store(candidate(projectId, req));
+    }
+
+    /**
+     * Bind a repo the caller only claims to be able to read, confirming it against the provider
+     * first. This is the path behind {@code POST /git/connect}, where the credential is typed in
+     * rather than handed to us by an install we watched happen.
+     *
+     * <p>Nothing is written unless the read succeeds. Without this, a typo'd or under-scoped token
+     * binds cleanly and RCA silently drops to trace-only evidence at the next run, with nothing on
+     * screen connecting the thin answer to the credential that caused it.
+     *
+     * <p>The provider also answers with the repo's real default branch, so an unspecified branch
+     * lands on what the repo actually uses instead of a hardcoded {@code main}.
+     */
+    public GitIntegrationRow connectVerified(String projectId, ConnectRequest req) {
+        GitIntegrationRow candidate = candidate(projectId, req);
+        RepoAccess access = providers.client(candidate.providerEnum()).verifyAccess(candidate);
+        boolean branchGiven =
+                req.defaultBranch() != null && !req.defaultBranch().isBlank();
+        return store(branchGiven ? candidate : withDefaultBranch(candidate, access.defaultBranch()));
+    }
+
+    /** The row a connect would write, sealed and validated, but not yet persisted. */
+    private GitIntegrationRow candidate(String projectId, ConnectRequest req) {
         GitProvider provider;
         try {
             provider = GitProvider.fromWire(req.provider());
@@ -52,10 +86,10 @@ public class GitIntegrationService {
             throw new TessaryException(GitError.DUPLICATE_INTEGRATION, projectId);
         }
 
-        String credentialsEnc = sealCredentials(provider, req);
+        String credentialsEnc = sealCredentials(req);
         String now = Instant.now().toString();
         String branch = (req.defaultBranch() == null || req.defaultBranch().isBlank()) ? "main" : req.defaultBranch();
-        GitIntegrationRow row = new GitIntegrationRow(
+        return new GitIntegrationRow(
                 Ids.ulid(),
                 projectId,
                 provider.wire(),
@@ -67,14 +101,32 @@ public class GitIntegrationService {
                 null,
                 now,
                 now);
+    }
+
+    private static GitIntegrationRow withDefaultBranch(GitIntegrationRow r, String branch) {
+        return new GitIntegrationRow(
+                r.id(),
+                r.projectId(),
+                r.provider(),
+                r.host(),
+                r.repoOwner(),
+                r.repoName(),
+                branch,
+                r.credentialsEnc(),
+                r.observerCursorSha(),
+                r.createdAt(),
+                r.updatedAt());
+    }
+
+    private GitIntegrationRow store(GitIntegrationRow row) {
         repo.insert(row);
         log.info(
                 Markers.OPS,
                 "git integration connected projectId={} provider={} repo={}/{}",
-                projectId,
-                provider.wire(),
-                req.repoOwner(),
-                req.repoName());
+                row.projectId(),
+                row.provider(),
+                row.repoOwner(),
+                row.repoName());
         return row;
     }
 
@@ -84,18 +136,18 @@ public class GitIntegrationService {
         return deleted;
     }
 
-    private String sealCredentials(GitProvider provider, ConnectRequest req) {
+    private String sealCredentials(ConnectRequest req) {
         Map<String, Object> creds = new LinkedHashMap<>();
         if (req.installationId() != null) creds.put("installationId", req.installationId());
         if (req.token() != null && !req.token().isBlank()) creds.put("token", req.token());
         if (creds.isEmpty()) return null;
         if (!secretBox.isConfigured()) {
-            throw new TessaryException(GitError.MISSING_APP_CONFIG, provider.wire());
+            throw new TessaryException(GitError.SECRET_KEY_MISSING);
         }
         try {
             return secretBox.seal(mapper.writeValueAsString(creds));
         } catch (Exception e) {
-            throw new TessaryException(GitError.MISSING_APP_CONFIG, e, provider.wire());
+            throw new TessaryException(GitError.SECRET_KEY_MISSING, e);
         }
     }
 }

--- a/backend/substrate/src/main/java/ai/tessary/git/GitProviderClient.java
+++ b/backend/substrate/src/main/java/ai/tessary/git/GitProviderClient.java
@@ -12,6 +12,23 @@ public interface GitProviderClient {
 
     GitProvider provider();
 
+    /**
+     * Confirm the integration's credentials can actually read the repo, and report what the provider
+     * knows about it. Called once at connect time, before anything is stored: without it a typo'd or
+     * under-scoped token binds cleanly and then fails silently at the first RCA, which reads as
+     * "Tessary ignored my repo" rather than as a credential the reader can fix.
+     *
+     * <p>Implementations must distinguish the failures a person recovers from differently:
+     * {@link ai.tessary.open.errors.GitError#CREDENTIALS_REJECTED} for a bad or expired credential,
+     * {@link ai.tessary.open.errors.GitError#REPO_ACCESS_DENIED} for an explicit refusal, and
+     * {@link ai.tessary.open.errors.GitError#REPO_UNREACHABLE} where the provider will not say
+     * whether the repo is absent or merely invisible.
+     */
+    RepoAccess verifyAccess(GitIntegrationRow integ);
+
+    /** What a provider tells us about a repo we can read. */
+    record RepoAccess(String defaultBranch) {}
+
     /** Current head SHA of {@code branch} (or the integration's default branch when null). */
     String resolveHeadSha(GitIntegrationRow integ, String branch);
 

--- a/backend/substrate/src/main/java/ai/tessary/git/github/GithubClient.java
+++ b/backend/substrate/src/main/java/ai/tessary/git/github/GithubClient.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -36,6 +37,8 @@ public class GithubClient implements GitProviderClient {
 
     private static final Logger log = LoggerFactory.getLogger(GithubClient.class);
     private static final String LABEL = "github";
+    /** The provider's own spelling, for messages a person reads rather than log lines. */
+    private static final String LABEL_TITLE = "GitHub";
 
     /** Bounded concurrency for fetching bundle blob contents (kept low to avoid GitHub secondary limits). */
     private static final int BLOB_FETCH_CONCURRENCY = 8;
@@ -61,6 +64,40 @@ public class GithubClient implements GitProviderClient {
     @Override
     public GitProvider provider() {
         return GitProvider.GITHUB;
+    }
+
+    /**
+     * {@code GET /repos/{owner}/{repo}} with the integration's own credentials. The status mapping is
+     * the point of the method: GitHub returns 404 (not 403) for a private repo a fine-grained token
+     * has not been granted, so a 404 cannot be reported as "no such repository" without frequently
+     * being wrong. 401 is unambiguous, 403 is an explicit refusal (SSO or an org policy), and every
+     * other non-2xx stays a plain provider failure rather than being read as a verdict about access.
+     */
+    @Override
+    public RepoAccess verifyAccess(GitIntegrationRow integ) {
+        String slug = integ.repoOwner() + "/" + integ.repoName();
+        URI uri = UrlGuard.requirePublicHttp(
+                baseUrl(integ) + "/repos/" + enc(integ.repoOwner()) + "/" + enc(integ.repoName()));
+        HttpResponse<String> res = exchange(baseRequest(integ, uri).GET().build());
+        TessaryException refusal = verifyRefusal(res.statusCode(), slug);
+        if (refusal != null) throw refusal;
+        JsonNode repo = validateAndParse(res);
+        String branch = repo.path("default_branch").asText("");
+        return new RepoAccess(branch.isBlank() ? "main" : branch);
+    }
+
+    /**
+     * The status-to-error mapping for {@link #verifyAccess}, split out so it can be pinned without
+     * an HTTP round trip ({@code UrlGuard} refuses to aim this client at a local test server).
+     * Null means the status is not a refusal and the body should be parsed.
+     */
+    static @Nullable TessaryException verifyRefusal(int status, String slug) {
+        return switch (status) {
+            case 401 -> new TessaryException(GitError.CREDENTIALS_REJECTED, LABEL_TITLE);
+            case 403 -> new TessaryException(GitError.REPO_ACCESS_DENIED, slug);
+            case 404 -> new TessaryException(GitError.REPO_UNREACHABLE, slug);
+            default -> null;
+        };
     }
 
     @Override

--- a/backend/substrate/src/test/java/ai/tessary/git/github/GithubClientVerifyAccessTest.java
+++ b/backend/substrate/src/test/java/ai/tessary/git/github/GithubClientVerifyAccessTest.java
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: Apache-2.0
+package ai.tessary.git.github;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import ai.tessary.open.errors.GitError;
+import ai.tessary.open.errors.TessaryException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What connect-time verification tells a person when GitHub says no.
+ *
+ * <p>The mapping is the whole point of the method, and getting 404 wrong is the expensive one:
+ * GitHub answers 404 both for a repository that does not exist and for a private one a fine-grained
+ * token was never granted, so "no such repository" would be confidently wrong for the commonest
+ * real failure — a correct name with an under-scoped token.
+ */
+class GithubClientVerifyAccessTest {
+
+    @Test
+    void unauthorized_readsAsARejectedCredential() {
+        TessaryException e = GithubClient.verifyRefusal(401, "acme/web");
+        assertNotNull(e);
+        assertEquals(GitError.CREDENTIALS_REJECTED, e.error());
+        assertTrue(e.getMessage().contains("GitHub"), "names the provider that did the rejecting");
+    }
+
+    @Test
+    void forbidden_readsAsAnExplicitRefusalOnThatRepo() {
+        TessaryException e = GithubClient.verifyRefusal(403, "acme/web");
+        assertNotNull(e);
+        assertEquals(GitError.REPO_ACCESS_DENIED, e.error());
+        assertTrue(e.getMessage().contains("acme/web"));
+    }
+
+    @Test
+    void notFound_coversBothReadingsRatherThanAssertingTheWrongOne() {
+        TessaryException e = GithubClient.verifyRefusal(404, "acme/web");
+        assertNotNull(e);
+        assertEquals(GitError.REPO_UNREACHABLE, e.error());
+        String msg = e.getMessage();
+        assertTrue(msg.contains("acme/web"));
+        // Both recovery paths have to be on screen, because the status cannot tell us which applies.
+        assertTrue(msg.contains("owner and repository name"), "the name might be wrong");
+        assertTrue(msg.contains("Contents: read"), "or the token might not reach it");
+    }
+
+    @Test
+    void successAndOtherStatuses_areNotRefusals() {
+        assertNull(GithubClient.verifyRefusal(200, "acme/web"));
+        // A 500 or a 429 is a provider failure, not a verdict about access: letting it fall through
+        // keeps it out of the "your token is wrong" copy, which would send someone to fix a token
+        // that was fine.
+        assertNull(GithubClient.verifyRefusal(500, "acme/web"));
+        assertNull(GithubClient.verifyRefusal(429, "acme/web"));
+    }
+}

--- a/backend/surfaces/src/test/java/ai/tessary/mcp/McpCaseToolsTest.java
+++ b/backend/surfaces/src/test/java/ai/tessary/mcp/McpCaseToolsTest.java
@@ -336,6 +336,7 @@ class McpCaseToolsTest {
                         "Model swap on 2026-08-14", "high", "The provider rotated the default.", List.of("tr-1"))),
                 "## Why\nThe judge model changed.",
                 "agentic",
+                true,
                 "2026-08-15T01:00:00Z",
                 "2026-08-15T01:20:00Z");
     }

--- a/frontend/src/api/generated/schema.d.ts
+++ b/frontend/src/api/generated/schema.d.ts
@@ -3446,6 +3446,7 @@ export interface components {
             metric: string;
             /** Format: double */
             prior_value: number;
+            repo_available: boolean | null;
             ruled_out: components["schemas"]["RuledOutCheck"][];
             status: string;
             subject_id: string;

--- a/frontend/src/routeManifest.smoke.test.tsx
+++ b/frontend/src/routeManifest.smoke.test.tsx
@@ -352,6 +352,9 @@ const SHELL_CHROME_OVERRIDES: Record<string, () => Promise<unknown>> = {
 const VIEW_OVERRIDES: Record<string, Record<string, () => Promise<unknown>>> = {
   "cases/:caseId": {
     getCase: NOT_FOUND("case"),
+    // The header offers "Connect repository" beside Run RCA when the project has none, so the
+    // case page now reads the integration too (useRepoPrompt).
+    getGitIntegration: () => Promise.resolve(null),
   },
   sources: {
     listSources: EMPTY,
@@ -398,6 +401,8 @@ const VIEW_OVERRIDES: Record<string, Record<string, () => Promise<unknown>>> = {
   },
   "rca/:reportId": {
     getRcaReport: NOT_FOUND("rca report"),
+    // Same read as the case page: the "analyzed without repository access" notice offers to fix it.
+    getGitIntegration: () => Promise.resolve(null),
   },
   // ---- Settings sections -----------------------------------------------------------------------
   // Every one of these mounts a view that reads at least one project endpoint on mount, and each

--- a/frontend/src/views/RcaReport.tsx
+++ b/frontend/src/views/RcaReport.tsx
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
+import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
+import { Info } from "lucide-react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useProjectApi, useTenant } from "../tenant/TenantContext";
 import { Badge, Button, Card, PageBody, PageHeader, Spinner, StatusPill, cn, type BadgeTone } from "../ui";
 import { Markdown } from "./components/PayloadViewer";
 import { RCA_JOB_STATUS, RCA_VERDICT_LABEL, RCA_VERDICT_TONE, rcaRunning } from "./rcaLabels";
+import { ConnectRepositoryDialog } from "./components/ConnectRepositoryDialog";
+import { useRepoPrompt } from "./components/useRepoPrompt";
 import type { RcaHypothesis, RcaRuledOutCheck } from "../api/types";
 
 /**
@@ -124,6 +128,8 @@ export function RcaReport() {
   const { orgSlug, projectSlug } = useTenant();
   const api = useProjectApi();
   const navigate = useNavigate();
+  const { canPrompt: canPromptRepo } = useRepoPrompt();
+  const [connectRepoOpen, setConnectRepoOpen] = useState(false);
 
   const report = useQuery({
     queryKey: ["rca-report", api.base, reportId],
@@ -230,6 +236,32 @@ export function RcaReport() {
         </div>
       )}
 
+      {/* A run that had no repository could show what changed in production and not what changed in
+          the code. That ceiling belongs above the verdict, because it qualifies the verdict — until
+          now it existed only as a sentence the agent wrote into the markdown body, where it reads as
+          part of the analysis rather than as a limit on it. `repo_available` is null on reports
+          written before it was recorded: unknown, which must not render as "no repository". */}
+      {!running && r.status === "done" && r.repo_available === false && (
+        <div
+          className="rounded-card border border-[color:var(--color-info)] px-3 py-2 mb-6 flex items-center justify-between gap-4"
+          style={{ backgroundColor: "var(--color-info-subtle)" }}
+        >
+          <div className="flex items-start gap-2">
+            <Info size={13} strokeWidth={1.75} aria-hidden="true" className="text-info shrink-0 mt-0.5" />
+            <span className="text-small text-fg-secondary">
+              <span className="font-medium text-fg">Analyzed without repository access.</span> Tessary analyzed trace
+              evidence only and could not check code changes. Connect a repository to include code in the next
+              analysis.
+            </span>
+          </div>
+          {canPromptRepo && (
+            <Button size="sm" variant="secondary" className="shrink-0" onClick={() => setConnectRepoOpen(true)}>
+              Connect repository
+            </Button>
+          )}
+        </div>
+      )}
+
       {!running && r.status === "done" && (
         <div className="flex flex-col gap-5">
           {r.verdict && (
@@ -271,6 +303,8 @@ export function RcaReport() {
           )}
         </div>
       )}
+
+      <ConnectRepositoryDialog open={connectRepoOpen} onClose={() => setConnectRepoOpen(false)} />
     </PageBody>
   );
 }

--- a/frontend/src/views/Settings/GitIntegration.tsx
+++ b/frontend/src/views/Settings/GitIntegration.tsx
@@ -36,7 +36,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
 import { useProjectApi } from "../../tenant/TenantContext";
 import type { InstallationOption } from "../../api/types";
-import { Button, ErrorNote, Field, Input, Modal, PageBody, PageHeader, Skeleton, useToast } from "../../ui";
+import { Button, ErrorNote, Modal, PageBody, PageHeader, Skeleton, useToast } from "../../ui";
+import { ConnectRepositoryDialog } from "../components/ConnectRepositoryDialog";
 
 export function GitIntegration() {
   const api = useProjectApi();
@@ -101,10 +102,10 @@ export function GitIntegration() {
     enabled: selectToken != null,
   });
 
-  const [owner, setOwner] = useState("");
-  const [name, setName] = useState("");
-  const [token, setToken] = useState("");
-  const [manualOpen, setManualOpen] = useState(false);
+  const [connectOpen, setConnectOpen] = useState(false);
+  // The App routes stay one disclosure back. A token works on every deployment; an App needs one
+  // registered first, so leading with it is what sent self-hosters through three dead buttons.
+  const [appOpen, setAppOpen] = useState(false);
 
   const installRedirect = useMutation({
     mutationFn: api.getGithubInstallUrl,
@@ -113,7 +114,7 @@ export function GitIntegration() {
     },
     // No hosted app configured (self-hosted, or the app isn't set up): fall back
     // to binding a repo by name rather than dead-ending.
-    onError: () => setManualOpen(true),
+    onError: () => setConnectOpen(true),
   });
 
   const authorizeRedirect = useMutation({
@@ -121,7 +122,7 @@ export function GitIntegration() {
     onSuccess: (res) => {
       window.location.href = res.url;
     },
-    onError: () => setManualOpen(true),
+    onError: () => setConnectOpen(true),
   });
 
   // GitHub's manifest flow needs a POSTed `manifest` form field — too large for a query string —
@@ -142,28 +143,7 @@ export function GitIntegration() {
       document.body.appendChild(form);
       form.submit();
     },
-    onError: () => toast.error("Could not start GitHub App setup", 'Try again, or select "Enter a repository by name".'),
-  });
-
-  const connect = useMutation({
-    mutationFn: () =>
-      api.connectGit({
-        provider: "github",
-        repoOwner: owner.trim(),
-        repoName: name.trim(),
-        // A blank token binds a repo the hosted/BYO App already reaches, same as before. A non-blank
-        // one is a personal-access-token fallback for a repo no App installation covers — the backend
-        // seals it and GithubTokenService tries it before ever touching App credentials.
-        token: token.trim() === "" ? undefined : token.trim(),
-      }),
-    onSuccess: () => {
-      setOwner("");
-      setName("");
-      setToken("");
-      setManualOpen(false);
-      invalidate();
-      toast.success("Repository connected");
-    },
+    onError: () => toast.error("Could not start GitHub App setup", "Try again, or connect with an access token."),
   });
 
   const select = useMutation({
@@ -195,12 +175,12 @@ export function GitIntegration() {
 
   return (
     <>
-      <PageHeader
-        eyebrow="Data & ingestion"
-        title="Git integration"
-        subtitle="The repository Tessary reads when it runs RCA (root-cause analysis). Without one, RCA still runs, but it rules on trace evidence alone and cannot say what changed in your code."
-      />
-      <PageBody>
+      <PageBody size="narrow">
+        <PageHeader
+          eyebrow="Data & ingestion"
+          title="Git integration"
+          subtitle="The repository Tessary reads when it runs RCA (root-cause analysis). Without one, RCA still runs, but it rules on trace evidence alone and cannot say what changed in your code."
+        />
         {integrationQ.isLoading && <Skeleton className="h-16 w-full" />}
         {integrationQ.isError && <ErrorNote error={integrationQ.error} />}
 
@@ -238,72 +218,56 @@ export function GitIntegration() {
               Until one is connected, RCA can still run but rules on trace evidence alone and cannot check your code.
             </p>
             <div className="flex items-center gap-2 mt-4" style={{ flexWrap: "wrap" }}>
-              <Button size="sm" onClick={() => installRedirect.mutate()} disabled={installRedirect.isPending}>
-                {installRedirect.isPending ? "Opening GitHub…" : "Install the GitHub App"}
+              <Button size="sm" variant="primary" onClick={() => setConnectOpen(true)}>
+                Connect repository
               </Button>
-              <Button
-                size="sm"
-                variant="secondary"
-                onClick={() => authorizeRedirect.mutate()}
-                disabled={authorizeRedirect.isPending}
-              >
-                Use an existing installation
-              </Button>
-              <Button size="sm" variant="ghost" onClick={() => setManualOpen(true)}>
-                Enter a repository by name
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                onClick={() => manifestSetup.mutate()}
-                disabled={manifestSetup.isPending}
-              >
-                {manifestSetup.isPending ? "Opening GitHub…" : "Set up your own GitHub App"}
-              </Button>
+              {!appOpen && (
+                <Button size="sm" variant="ghost" onClick={() => setAppOpen(true)}>
+                  Use a GitHub App instead
+                </Button>
+              )}
             </div>
+
+            {appOpen && (
+              <div className="border-t border-border mt-4 pt-4">
+                <div className="text-label uppercase text-subtle">GitHub App</div>
+                <div className="flex items-center gap-2 mt-2.5" style={{ flexWrap: "wrap" }}>
+                  <Button size="sm" onClick={() => installRedirect.mutate()} disabled={installRedirect.isPending}>
+                    {installRedirect.isPending ? "Opening GitHub…" : "Install the GitHub App"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    onClick={() => authorizeRedirect.mutate()}
+                    disabled={authorizeRedirect.isPending}
+                  >
+                    Use an existing installation
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => manifestSetup.mutate()}
+                    disabled={manifestSetup.isPending}
+                  >
+                    {manifestSetup.isPending ? "Opening GitHub…" : "Set up your own GitHub App"}
+                  </Button>
+                </div>
+              </div>
+            )}
           </div>
         )}
 
         {disconnect.isError && <ErrorNote error={disconnect.error} />}
       </PageBody>
 
-      <Modal open={manualOpen} onClose={() => setManualOpen(false)} title="Connect a repository">
-        <p className="text-muted mt-0 mx-0 mb-4 text-body">
-          Either the GitHub App already has access to this repository, or paste a personal access
-          token below for a repository no App installation reaches. The token needs read access to
-          code and metadata. Leave it blank to connect through the App instead.
-        </p>
-        <Field label="Owner">
-          {(p) => <Input {...p} value={owner} onChange={(e) => setOwner(e.target.value)} placeholder="tessaryai" autoFocus />}
-        </Field>
-        <Field label="Repository">
-          {(p) => <Input {...p} value={name} onChange={(e) => setName(e.target.value)} placeholder="tessary" />}
-        </Field>
-        <Field label="Personal access token (optional)">
-          {(p) => (
-            <Input
-              {...p}
-              type="password"
-              value={token}
-              onChange={(e) => setToken(e.target.value)}
-              placeholder="ghp_… or github_pat_…"
-            />
-          )}
-        </Field>
-        {connect.isError && <ErrorNote error={connect.error} />}
-        <div className="flex justify-end gap-2 mt-4.5">
-          <Button variant="ghost" size="sm" onClick={() => setManualOpen(false)}>
-            Cancel
-          </Button>
-          <Button
-            size="sm"
-            onClick={() => connect.mutate()}
-            disabled={connect.isPending || owner.trim() === "" || name.trim() === ""}
-          >
-            {connect.isPending ? "Connecting…" : "Connect repository"}
-          </Button>
-        </div>
-      </Modal>
+      <ConnectRepositoryDialog
+        open={connectOpen}
+        onClose={() => setConnectOpen(false)}
+        onUseGithubApp={() => {
+          setConnectOpen(false);
+          setAppOpen(true);
+        }}
+      />
 
       <Modal
         open={selectToken != null}

--- a/frontend/src/views/components/ConnectRepositoryDialog.tsx
+++ b/frontend/src/views/components/ConnectRepositoryDialog.tsx
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * The one dialog that binds a repository to a project, wherever the ask starts:
+ * Settings → Git integration, the case page beside Run RCA, or the notice on an
+ * RCA report that had no repo to read. All three open this, in place — someone
+ * reading a failure should not lose their place to go configure something.
+ *
+ * An access token is the default and the GitHub App is the secondary path, which
+ * is the reverse of how this used to read. The token is the only route that works
+ * on every deployment: a self-hoster with no App configured used to meet three
+ * buttons that dead-end before finding the field that binds a repo.
+ *
+ * Making a token is explained HERE rather than in a docs page, because the five
+ * lines it takes are the whole distance between someone and a working connection.
+ * The one unavoidable trip is github.com itself, which is the only place a token
+ * can be minted; that opens in a new tab and leaves this dialog sitting where it
+ * was, so nothing typed is lost.
+ */
+import { useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ChevronRight, CircleAlert, ExternalLink } from "lucide-react";
+import { useProjectApi } from "../../tenant/TenantContext";
+import { ApiError } from "../../api/types";
+import { Button, Field, Input, Modal, useToast } from "../../ui";
+
+/**
+ * Split `owner/name` out of whatever someone pasted: a browser URL, an SSH-ish
+ * `github.com/owner/name`, a `.git` suffix, or the bare slug. Returns null until
+ * both halves are present, which is also what gates the submit button.
+ */
+export function parseRepo(input: string): { owner: string; name: string } | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const bare = trimmed
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, "")
+    .replace(/^git@/i, "")
+    .replace(/^www\./i, "")
+    .replace(/^github\.com[/:]/i, "")
+    .replace(/\.git$/i, "")
+    .replace(/[/]+$/, "");
+  const parts = bare.split("/").filter((p) => p.length > 0);
+  if (parts.length < 2) return null;
+  return { owner: parts[0], name: parts[1] };
+}
+
+/**
+ * GitHub's template URL for a fine-grained token, prefilled as far as GitHub allows.
+ *
+ * `target_name` scopes the resource-owner dropdown, and the permission and expiry
+ * arrive set. There is no parameter for the repository picker, so the repository
+ * rides in `description` instead: that is the one prefillable field that renders as
+ * readable text on GitHub's own form, which is where the person is standing when
+ * they have to pick it. `name` is capped at 40 characters by GitHub, past which the
+ * parameter is dropped rather than truncated.
+ */
+export function tokenTemplateUrl(repo: { owner: string; name: string } | null): string {
+  const slug = repo ? `${repo.owner}/${repo.name}` : null;
+  const params = new URLSearchParams();
+  params.set("name", (slug ? `Tessary: ${slug}` : "Tessary").slice(0, 40));
+  params.set(
+    "description",
+    slug
+      ? `Read-only access for Tessary root-cause analysis. Under Repository access, select only ${slug}.`
+      : "Read-only access for Tessary root-cause analysis.",
+  );
+  if (repo) params.set("target_name", repo.owner);
+  params.set("expires_in", "90");
+  params.set("contents", "read");
+  return `https://github.com/settings/personal-access-tokens/new?${params.toString()}`;
+}
+
+export function ConnectRepositoryDialog({
+  open,
+  onClose,
+  onConnected,
+  onUseGithubApp,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onConnected?: () => void;
+  /** Omitted where the App path has no home, e.g. the dialog opened from a case. */
+  onUseGithubApp?: () => void;
+}) {
+  const api = useProjectApi();
+  const qc = useQueryClient();
+  const toast = useToast();
+
+  const [repoInput, setRepoInput] = useState("");
+  const [token, setToken] = useState("");
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  const repo = parseRepo(repoInput);
+
+  const connect = useMutation({
+    mutationFn: () =>
+      api.connectGit({
+        provider: "github",
+        repoOwner: repo?.owner ?? "",
+        repoName: repo?.name ?? "",
+        token: token.trim() === "" ? undefined : token.trim(),
+      }),
+    onSuccess: () => {
+      setRepoInput("");
+      setToken("");
+      setHelpOpen(false);
+      void qc.invalidateQueries({ queryKey: ["git-integration", api.base] });
+      toast.success("Repository connected");
+      onConnected?.();
+      onClose();
+    },
+  });
+
+  // Grey text with an error-colored icon, never red body copy: red passes contrast
+  // only in the large-or-bold class (DESIGN_SYSTEM.md § States).
+  const error = connect.error ? (connect.error as ApiError).detail ?? "The request failed. Try again." : null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title="Connect repository"
+      subtitle="Tessary reads this repository during RCA (root-cause analysis) to check what changed in your code."
+      footer={
+        <>
+          {onUseGithubApp && (
+            <Button variant="ghost" size="sm" className="mr-auto" onClick={onUseGithubApp}>
+              Use a GitHub App instead
+            </Button>
+          )}
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            loading={connect.isPending}
+            disabled={connect.isPending || repo == null}
+            onClick={() => connect.mutate()}
+          >
+            {connect.isPending ? "Connecting…" : "Connect repository"}
+          </Button>
+        </>
+      }
+    >
+      <Field label="Repository">
+        {(p) => (
+          <Input
+            {...p}
+            value={repoInput}
+            onChange={(e) => setRepoInput(e.target.value)}
+            placeholder="owner/name or GitHub URL"
+            autoFocus
+          />
+        )}
+      </Field>
+
+      <Field
+        label="Access token"
+        className="mt-4"
+        hint="Tessary stores the token encrypted and uses it only to clone the repository."
+      >
+        {(p) => (
+          <Input {...p} type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="" />
+        )}
+      </Field>
+
+      <button
+        type="button"
+        onClick={() => setHelpOpen((v) => !v)}
+        className="mt-2.5 flex items-center gap-1.5 text-small text-fg"
+      >
+        <ChevronRight
+          size={11}
+          strokeWidth={1.75}
+          aria-hidden="true"
+          className="text-muted transition-transform"
+          style={{
+            transform: helpOpen ? "rotate(90deg)" : "rotate(0deg)",
+            transitionDuration: "var(--duration-micro)" }}
+        />
+        How to create a token
+      </button>
+
+      {helpOpen && (
+        <div className="bg-raised rounded-card mt-2.5 px-4 py-3.5">
+          <ol className="flex flex-col gap-3 m-0 p-0" style={{ listStyle: "none" }}>
+            <Step n={1}>
+              <div className="text-small text-fg-secondary">Create a fine-grained token on GitHub.</div>
+              <Button
+                variant="secondary"
+                size="sm"
+                className="mt-2"
+                trailingIcon={<ExternalLink size={11} strokeWidth={1.75} aria-hidden="true" />}
+                onClick={() => window.open(tokenTemplateUrl(repo), "_blank", "noopener,noreferrer")}
+              >
+                Create a token on GitHub
+              </Button>
+              <div className="text-small text-subtle mt-2">
+                Opens GitHub with the resource owner, expiration, and <span className="font-mono">Contents: read</span>{" "}
+                already set.
+              </div>
+            </Step>
+            <Step n={2}>
+              <div className="text-small text-fg-secondary">
+                Under <span className="font-mono">Repository access</span>, select{" "}
+                {repo ? <span className="font-mono">{`${repo.owner}/${repo.name}`}</span> : "your repository"}.
+              </div>
+            </Step>
+            <Step n={3}>
+              <div className="text-small text-fg-secondary">
+                Select <span className="font-mono">Generate token</span>, copy it, and paste it above.
+              </div>
+            </Step>
+          </ol>
+          <div className="border-t border-border mt-3.5 pt-3 flex flex-col gap-2">
+            <div className="text-small text-subtle">
+              Tessary can't renew an expired token. RCA continues without repository access until you replace it.
+            </div>
+            <div className="text-small text-subtle">
+              If the repository belongs to an organization, an organization owner approves the token before it works.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div
+          role="alert"
+          className="rounded-card border border-[color:var(--color-error)] mt-4 px-3 py-2 flex items-start gap-2"
+          style={{ backgroundColor: "var(--color-error-subtle)" }}
+        >
+          <CircleAlert size={13} strokeWidth={1.75} aria-hidden="true" className="text-error shrink-0 mt-0.5" />
+          <span className="text-small text-fg-secondary">
+            <span className="font-medium text-fg">Connection failed.</span> {error}
+          </span>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function Step({ n, children }: { n: number; children: React.ReactNode }) {
+  return (
+    <li className="flex items-start gap-2.5">
+      <span
+        aria-hidden="true"
+        className="rounded-pill border border-border text-label text-muted shrink-0 inline-flex items-center justify-center"
+        style={{ width: 18, height: 18, marginTop: 1 }}
+      >
+        {n}
+      </span>
+      <div className="min-w-0">{children}</div>
+    </li>
+  );
+}

--- a/frontend/src/views/components/useRepoPrompt.ts
+++ b/frontend/src/views/components/useRepoPrompt.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+import { useQuery } from "@tanstack/react-query";
+import { useAuth } from "../../auth/AuthContext";
+import { useProjectApi, useTenant } from "../../tenant/TenantContext";
+
+/**
+ * Whether to offer "Connect repository" on a surface that is not Settings.
+ *
+ * Two conditions, and both have to be known rather than assumed. Connecting is owner-gated
+ * server-side, so a reader who cannot act on the offer is not shown it. And the offer is only
+ * honest while the project genuinely has no repository: a pending or failed read of the
+ * integration claims nothing, because prompting someone to connect a repo they already connected
+ * reads as the product having lost it.
+ *
+ * The integration query shares its key with Settings → Git integration, so opening a case after
+ * connecting one costs no extra request and the button disappears on the same cache entry.
+ */
+export function useRepoPrompt(): { canPrompt: boolean } {
+  const api = useProjectApi();
+  const { orgSlug } = useTenant();
+  const { user } = useAuth();
+
+  const integration = useQuery({
+    queryKey: ["git-integration", api.base],
+    queryFn: api.getGitIntegration,
+  });
+
+  const isOwner = user?.orgs.find((o) => o.slug === orgSlug)?.role === "owner";
+  return { canPrompt: isOwner && integration.isSuccess && integration.data == null };
+}

--- a/frontend/src/views/triage/CasePage.tsx
+++ b/frontend/src/views/triage/CasePage.tsx
@@ -49,6 +49,8 @@ import { rcaRunning, RCA_VERDICT_LABEL } from "../rcaLabels";
 import { RateChart, RatePins } from "../classifiers/rateStory";
 import { ShiftChart, ShiftPins } from "../classifiers/shiftStory";
 import { Dot, ListChassis, StateDot, causeLine, detectorLabel, displayCallSite, timeAgo, truncateId } from "./bits";
+import { ConnectRepositoryDialog } from "../components/ConnectRepositoryDialog";
+import { useRepoPrompt } from "../components/useRepoPrompt";
 import { formatDuration } from "../traces/detail-data";
 
 /** `2026-08-24T18:00:00Z` → `24 Aug 18:00`. The window is the story's spine, so it reads as a clock. */
@@ -90,6 +92,8 @@ export function CasePage() {
 
 
   const rcaEnabled = useCapabilities().isEnabled("rca_enabled");
+  const { canPrompt: canPromptRepo } = useRepoPrompt();
+  const [connectRepoOpen, setConnectRepoOpen] = useState(false);
 
   const [resolveOpen, setResolveOpen] = useState(false);
   const [absorbOpen, setAbsorbOpen] = useState(false);
@@ -205,7 +209,16 @@ export function CasePage() {
               of a story, not offered at the top of it; they moved to the closing bar with Mute.
               What stays is the one thing the reader can do before they have read anything. */}
           {live && detail.detector_available && rcaEnabled && detail.rca_available && (
-            <div className="ml-auto flex shrink-0 items-center">
+            <div className="ml-auto flex shrink-0 items-center gap-2">
+              {/* The second control here is deliberate and temporary: an RCA with no repo rules on
+                  trace evidence alone, and the moment before someone presses Run is the only one
+                  where that is still fixable. It is owner-gated and disappears for good once a
+                  repository is connected, so the page returns to its one-control rule by itself. */}
+              {canPromptRepo && (
+                <Button size="sm" variant="secondary" onClick={() => setConnectRepoOpen(true)}>
+                  Connect repository
+                </Button>
+              )}
               <Button
                 size="sm"
                 variant={analysed ? "secondary" : "primary"}
@@ -387,6 +400,8 @@ export function CasePage() {
           </Button>
         </div>
       </Modal>
+
+      <ConnectRepositoryDialog open={connectRepoOpen} onClose={() => setConnectRepoOpen(false)} />
     </div>
   );
 }


### PR DESCRIPTION
## What changed

Connecting a repository led with the GitHub App, which has to be registered before it works. A self-hoster with no App met three buttons that dead-end before finding the field that actually binds a repo. An access token is the one route that works on every deployment, so it becomes the default and the App moves behind a disclosure.

Connect also never asked GitHub anything. A typo'd or under-scoped token bound cleanly, and the next thing that noticed was an RCA quietly ruling on trace evidence alone, with nothing on screen connecting the thinner answer to the credential that caused it.

### Backend

- `POST /git/connect` now reads `GET /repos/{owner}/{repo}` with the credential before storing anything. A refused read stores nothing.
- `GitIntegrationService.connect` is unchanged and still serves the App install callbacks, which already proved the repo off an installation the authorizing user was verified to administer. Only the typed-in path verifies.
- The default branch comes from that response instead of a hardcoded `main`.
- Four new error codes, each naming a different recovery. `SECRET_KEY_MISSING` replaces `MISSING_APP_CONFIG` on the token path, which used to tell someone to configure the very thing a token exists to avoid.
- Migration `0024` adds `rca_report.repo_available`, recording whether a run had the repo.

### Frontend

One `ConnectRepositoryDialog` behind all three surfaces, opened in place so nobody reading a failure loses their place to go configure something.

- **Case page:** `Connect repository` left of Run RCA, owner-gated, and only once the integration read has come back empty. It disappears for good on connect, so the page returns to its one-control rule by itself.
- **RCA report:** "Analyzed without repository access" above the verdict, because it qualifies the verdict.
- **Settings:** `Connect repository` is primary; the App buttons moved behind "Use a GitHub App instead".

Making a token is explained inside the dialog rather than in a docs page. "Create a token on GitHub" builds GitHub's [template URL](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) from what was typed.

## Two decisions worth a reviewer's attention

**A 404 is not reported as "no such repository."** GitHub answers 404 both for a repository that does not exist and for a private one a fine-grained token was never granted, and does not say which. `REPO_UNREACHABLE` carries both recovery paths, because asserting the first would be confidently wrong for the commonest real failure: a correct name with an under-scoped token.

**`repo_available` is nullable.** Reports written before the column cannot answer, and unknown must not render as "no repository" (the UI checks `=== false`, not falsiness). Asking whether a repo is connected *now* would tell the wrong story about a report from before it was, and the opposite story after someone disconnects.

GitHub has no query parameter for the repository picker, so the repository rides in `description`, the one prefillable field that renders as readable text on GitHub's own form. Note also that `target_name` has [a reported bug](https://github.com/orgs/community/discussions/188111) where it fills the dropdown visually without setting form state, so the resource owner is worth confirming by eye.

## What I verified

- `GithubClientVerifyAccessTest` (new): the status-to-error mapping, including that 500 and 429 stay provider failures rather than becoming verdicts about access. Split out as a package-private static because `UrlGuard` refuses to aim this client at a local test server.
- `GitIntegrationServiceTest` (extended): the provider's default branch wins when none was given, an explicit branch wins over it, **a refused connect leaves the project unbound**, and `connect()` does not call the provider at all.
- Existing suites touched by the new field: `RcaWorkerTest`, `CaseServiceTest`, `McpCaseToolsTest`, `AgenticRcaPromptTest`, `OpenApiSpecDriftTest`. All pass. Spec and frontend types regenerated.
- Frontend: `tsc --noEmit` clean, 85 tests pass, `pnpm build` clean. The route smoke test gained `getGitIntegration` overrides for the two routes that now read it.

**Not verified by clicking through it.** The dev stack needs auth I did not want to handle, so the UI is covered by types and the mount smoke test rather than by eye. Worth a manual pass on the three surfaces before merge, particularly the dialog's error states.

## Still open

The GitHub App path is untouched. If self-hosting is the only consumer, the install, authorize, picker and manifest-wizard flows are roughly 1,200 lines that could follow this change out. Nothing here would be wasted either way.

## AI disclosure

Authored by Claude Opus 5 in Claude Code, at the direction of the repository owner, per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
