### PR TITLE
build(images): move to Node 24, then upgrade what we run and delete what we don't

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -87,6 +87,27 @@ LABEL org.opencontainers.image.version=$IMAGE_VERSION \
 WORKDIR /app
 RUN printf '%s\n' "$IMAGE_VERSION" > /app/IMAGE_VERSION
 
+# Delete Canonical's Pebble service manager. eclipse-temurin:25-jre is built on Ubuntu 26.04, which
+# bakes /usr/bin/pebble into the rootfs, and that binary was compiled with Go 1.26.5 — inside the
+# range of CVE-2026-39821 (>=1.26.0, <1.26.6). It is the only critical this image carries, and
+# nothing here starts it: the entrypoint below is java, straight through.
+#
+# THIS LINE DOES NOT MOVE THE SCANNER NUMBER, AND IS STILL WORTH KEEPING. Measured on the image
+# built from this file: every ELF on the filesystem was checked for a `go1.x` build stamp and NONE
+# carries one — there is no Go binary left to execute — yet `docker scout cves` still reports
+# `pkg:golang/stdlib@1.26.5` and lists `github.com/canonical/pebble` in the SBOM. Scout attributes
+# findings from the base image it detects (here `oisupport/staging-arm64v8:25-jre`, auto-detected
+# because a local build carries no provenance attestation) rather than from the flattened
+# filesystem alone. Which of those two paths produces this specific entry was not isolated, and it
+# does not change what to do: the reachable risk is gone, the reported count stays at 1C until
+# Temurin rebuilds on Go >=1.26.6.
+#
+# Do NOT try to win the number back by flattening the image (export/import, --squash). That would
+# discard the layered-jar COPY order below, whose whole purpose is that a code-only rebuild
+# invalidates just the small `application` layer, and it would drop the OCI labels and USER with
+# it. A phantom finding is not worth that trade.
+RUN rm -f /usr/bin/pebble
+
 # Run as an unprivileged user (the JRE base ships root by default).
 RUN groupadd --system spring && useradd --system --gid spring spring
 USER spring:spring

--- a/classify-service/Dockerfile
+++ b/classify-service/Dockerfile
@@ -31,7 +31,7 @@
 # ---------------------------------------------------------------------------
 # Stage 1: model bake — downloads pinned revisions, assembles localModelPath layout
 # ---------------------------------------------------------------------------
-FROM node:22-slim AS models
+FROM node:24-slim AS models
 
 WORKDIR /app
 # pnpm by explicit global install rather than corepack, so image builds never depend on corepack's
@@ -70,7 +70,7 @@ RUN --mount=type=secret,id=hf_token \
 # ---------------------------------------------------------------------------
 # Stage 2: runtime — code + baked weights + offline validation
 # ---------------------------------------------------------------------------
-FROM node:22-slim
+FROM node:24-slim
 
 WORKDIR /app
 ARG PNPM_VERSION

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -423,7 +423,7 @@ services:
   # from the OBSERVER_LAUNCHER_-prefixed SSM vars so they never override the backend container's
   # instance-profile creds.
   # One-shot init: Docker creates a fresh named volume as root:root mode 0755, unwritable by
-  # sandbox-runner's non-root `node` user (uid 1000, the default in node:22-slim; see
+  # sandbox-runner's non-root `node` user (uid 1000, the default in node:24-alpine3.24; see
   # sandbox-runner/launcher/Dockerfile's final `USER node`). This runs as root and chowns it to
   # 1000:1000 so the launcher's mkdtempSync calls (server.js's LAUNCHER_WORK_DIR) succeed. Exits
   # immediately; sandbox-runner waits on it via `condition: service_completed_successfully` below.
@@ -465,7 +465,7 @@ services:
     expose:
       - "8080"
     # The launcher's own GET /healthz (sandbox-runner/launcher/server.js), unauthenticated by
-    # design; node:22-alpine carries busybox wget. Same 5 s interval as the others, so a
+    # design; node:24-alpine carries busybox wget. Same 5 s interval as the others, so a
     # launcher that exits on a config it rejects shows as unhealthy, not merely restarting.
     healthcheck:
       test: ["CMD", "wget", "-q", "-O", "/dev/null", "-T", "3", "http://127.0.0.1:8080/healthz"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -62,9 +62,14 @@ FROM caddy:2-alpine AS runtime
 # as a convenience, and nothing here calls it — Caddy is a static Go binary that uses crypto/tls
 # and never links libcurl, the compose healthcheck uses busybox wget, and caddy/entrypoint.sh
 # shells out to neither. Deleting is the stronger of the two because it is permanent, where an
-# upgrade only holds until the next advisory. `apk del` cascades to the orphans (libidn2,
-# libunistring, nghttp2); libcurl has exactly one reverse dependency, curl itself, so nothing else
-# loses a library. Verified on the built image: caddy runs and busybox wget still does HTTPS.
+# upgrade only holds until the next advisory. libcurl has exactly one reverse dependency — curl
+# itself — so `apk del` takes the whole subtree with it: NINE packages, not two. Measured, in
+# order: curl, libcurl, libpsl, nghttp2-libs, zstd-libs, brotli-libs, c-ares, libidn2,
+# libunistring. Two of those names look alarming for a web server and are not: Caddy is a static
+# Go binary that links none of them, and `encode gzip` in caddy/base.caddy is the only compression
+# this site configures — brotli and zstd were never enabled, so purging their C libraries changes
+# nothing. Verified on the built image, both arches: caddy serves, gzip still negotiates, busybox
+# wget still does HTTPS.
 RUN apk upgrade --no-cache \
     && apk del --no-cache curl libcurl \
     && apk add --no-cache libcap \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -55,7 +55,19 @@ FROM caddy:2-alpine AS runtime
 # capabilities set on a binary do not survive a `COPY --from=`, so this only works because there is
 # no cross-stage copy of the caddy binary any more. The grant itself is required, not optional: the
 # TLS decision above means Caddy still binds :443, a privileged port, as a non-root process.
-RUN apk add --no-cache libcap \
+# `apk upgrade` and the curl removal are the two halves of this image's critical count, and they
+# are deliberately different moves. UPGRADE what we run: caddy:2-alpine is rebuilt on Caddy's
+# release cadence, not Alpine's, so its openssl (libcrypto3/libssl3) lags the patched
+# 3.5.8-r0 sitting in the 3.23 repo. DELETE what we don't: the base bundles a curl binary purely
+# as a convenience, and nothing here calls it — Caddy is a static Go binary that uses crypto/tls
+# and never links libcurl, the compose healthcheck uses busybox wget, and caddy/entrypoint.sh
+# shells out to neither. Deleting is the stronger of the two because it is permanent, where an
+# upgrade only holds until the next advisory. `apk del` cascades to the orphans (libidn2,
+# libunistring, nghttp2); libcurl has exactly one reverse dependency, curl itself, so nothing else
+# loses a library. Verified on the built image: caddy runs and busybox wget still does HTTPS.
+RUN apk upgrade --no-cache \
+    && apk del --no-cache curl libcurl \
+    && apk add --no-cache libcap \
     && setcap 'cap_net_bind_service=+ep' /usr/bin/caddy \
     && addgroup -S caddy && adduser -S -G caddy caddy \
     && chown -R caddy:caddy /data /config /etc/caddy

--- a/sandbox-runner/agent-sandbox/Dockerfile
+++ b/sandbox-runner/agent-sandbox/Dockerfile
@@ -78,7 +78,16 @@ FROM node:24-alpine3.24
 # apkInstall. The base's python3 ships WITHOUT pip and WITHOUT PyYAML, so the validator
 # (validate.py + pipeline_io.py, both of which `import yaml`) is a hard in-container crash without
 # this.
-RUN apk add --no-cache bash git ca-certificates python3 py3-pip make g++ linux-headers
+#
+# `apk upgrade` first, for the same reason as launcher/Dockerfile's: node:24-alpine3.24 is rebuilt
+# on Node's cadence, not Alpine's, so its openssl lags the 3.24 repo and is the only critical this
+# image carries. NOTE THE ASYMMETRY WITH THE LAUNCHER, which also DELETES npm and pnpm: nothing may
+# be deleted here. This image is a sandbox for agent code, and npm, python3, pip, git and the
+# compilers are its working surface at runtime, not build-time bootstraps —
+# PIP_BREAK_SYSTEM_PACKAGES below exists precisely so the agent can `pip install` mid-run. "Delete
+# what you don't run" is the right rule and it simply does not reach anything here.
+RUN apk upgrade --no-cache \
+    && apk add --no-cache bash git ca-certificates python3 py3-pip make g++ linux-headers
 
 # PyYAML is the validator's only required third-party Python dep, baked at build time (no
 # per-run network install). --break-system-packages: Alpine's python3, like Debian's, marks the

--- a/sandbox-runner/agent-sandbox/Dockerfile
+++ b/sandbox-runner/agent-sandbox/Dockerfile
@@ -21,11 +21,21 @@
 # No CMD/ENTRYPOINT: the docker driver runs `node <script>.js /work/input.json` per invocation
 # (see runScriptInDocker), never a long-lived process.
 #
-# BASE IMAGE: node:22-alpine3.24, the SAME as template.ts (E2B), kept in lockstep with it.
-# Why not 20: `re2@1.26.1` — pinned by every recipe, unchanged — declares
-# `engines.node: "^22.22.2 || ^24.15.0 || >=26.0.0"`, and npm's own resolved node-gyp fails to even
-# configure under Node 20 with an unrelated undici crash (`TypeError:
-# webidl.util.markAsUncloneable is not a function`), verified on both linux/amd64 and linux/arm64.
+# BASE IMAGE: node:24-alpine3.24, the SAME as template.ts (E2B), kept in lockstep with it.
+# Why 24 and not 22: 22 has been maintenance-only since 2025-10-21 and is EOL 2027-04-30; 24 runs
+# to 2028-04-30. `re2@1.26.1` — pinned by every recipe, unchanged — declares
+# `engines.node: "^22.22.2 || ^24.15.0 || >=26.0.0"`, so 24 is in range where 20 never was (under
+# 20, npm's own resolved node-gyp fails to even configure with an unrelated undici crash,
+# `TypeError: webidl.util.markAsUncloneable is not a function`, verified on both linux/amd64 and
+# linux/arm64).
+#
+# WHAT THE 22->24 MOVE COSTS, and why `linux-headers` is in the apk list below: re2 publishes
+# prebuilt binaries per Node ABI, and its install script tries those before compiling. Node 22 is
+# ABI 127 and has a musl prebuild; Node 24 is ABI 137 and does NOT, so `npm install re2` now falls
+# through to a from-source node-gyp build — which needs kernel headers for abseil's
+# direct_mmap.h (`fatal error: linux/unistd.h: No such file or directory`, hit on the first
+# 24 build). Keep linux-headers as long as re2 is in the install list below, whatever the Node
+# major: the source path is ABI-agnostic and is now the path this image always takes.
 # The launcher's own Dockerfile is on the same base for the same reasons.
 #
 # Why ALPINE and not Debian: every remaining CRITICAL on the Debian recipe was an unfixable Debian
@@ -50,28 +60,25 @@
 #
 # The musl swap itself is verified, not assumed: re2@1.26.1 compiles under Alpine's g++ and matches
 # correctly, opencode-ai 1.18.30 installs and runs, PyYAML imports, and @opencode-ai/sdk loads.
-FROM node:22-alpine3.24
+FROM node:24-alpine3.24
 
-# The `tar` module npm vendors (usr/local/lib/node_modules/npm/node_modules/tar) ships at 7.5.11 on
-# this base — the distro choice above doesn't touch npm's payload — and carries CRITICAL
-# CVE-2026-59873 (gzip-bomb DoS), fixed at tar@7.5.19. Patch the vendored copy in place rather than
-# bumping npm itself: npm>=12 (the first release vendoring a fixed tar) flips `allowScripts` off by
-# default, so `npm install re2@^1.26.1` below would complete with only a WARNING, never run
-# node-gyp, and ship an re2 that throws MODULE_NOT_FOUND at require time. Verified directly.
-# (launcher/Dockerfile fixes the same CVE with npm@12 instead — it installs with pnpm and builds no
-# native addon, so the allowScripts default is harmless there. Do not copy that line into here.)
-RUN npm install -g tar@7.5.19 --prefix /tmp/tarfix \
-    && cp -r /tmp/tarfix/lib/node_modules/tar/* /usr/local/lib/node_modules/npm/node_modules/tar/ \
-    && rm -rf /tmp/tarfix \
-    && npm cache clean --force
+# NO TAR PATCH HERE ANY MORE, and it should not come back. This used to copy tar@7.5.19 over the
+# copy npm vendors at usr/local/lib/node_modules/npm/node_modules/tar, because node:22-alpine3.24's
+# npm 10.9.8 vendored tar 7.5.11 and carried CRITICAL CVE-2026-59873 (gzip-bomb DoS).
+# node:24-alpine3.24 ships npm 11.19.0, whose vendored tar is ALREADY 7.5.19 — verified on the
+# base, not assumed — so the patch was a no-op the moment the base moved. Bumping npm itself is
+# still the wrong fix if this ever recurs: npm>=12 flips `allowScripts` off by default, so
+# `npm install re2@^1.26.1` below would complete with only a WARNING, never run node-gyp, and ship
+# an re2 that throws MODULE_NOT_FOUND at require time. Patch the vendored copy, don't bump npm.
 
-# git + the agent's clone; python3/py3-pip run the baked bundle validator; make/g++ build re2 (a
-# native addon); bash because the e2b SDK execs /bin/bash (see the header). Mirrored by
+# git + the agent's clone; python3/py3-pip run the baked bundle validator; make/g++/linux-headers
+# build re2 from source (a native addon with no Node 24 prebuild — see the header); bash because
+# the e2b SDK execs /bin/bash (see the header). Mirrored by
 # template.ts's `.runCmd('apk add ...')` — which is a raw runCmd because the builder has no
 # apkInstall. The base's python3 ships WITHOUT pip and WITHOUT PyYAML, so the validator
 # (validate.py + pipeline_io.py, both of which `import yaml`) is a hard in-container crash without
 # this.
-RUN apk add --no-cache bash git ca-certificates python3 py3-pip make g++
+RUN apk add --no-cache bash git ca-certificates python3 py3-pip make g++ linux-headers
 
 # PyYAML is the validator's only required third-party Python dep, baked at build time (no
 # per-run network install). --break-system-packages: Alpine's python3, like Debian's, marks the
@@ -136,7 +143,8 @@ WORKDIR /home/user
 # DELIBERATELY npm though the repo is otherwise on pnpm — see template.ts's own comment;
 # the same reasoning applies unchanged here (no lockfile to honor, the container is disposable, npm
 # is already in the base image). undici pins to ^6 so this line stays byte-identical to
-# template.ts's (bump every recipe together; undici 8 needs node >=22.19, fine on node:22-alpine3.24).
+# template.ts's (bump every recipe together; undici 8 needs node >=22.19, comfortably clear on
+# node:24-alpine3.24).
 # The cache clean is size only: npm leaves ~38 MB in $HOME/.npm that nothing at runtime reads.
 RUN npm install acorn@^8.18.0 acorn-walk@^8.3.5 re2@^1.26.1 @opencode-ai/sdk@1.18.30 undici@^6.28.0 \
     && npm cache clean --force

--- a/sandbox-runner/agent-sandbox/agent-stream.js
+++ b/sandbox-runner/agent-sandbox/agent-stream.js
@@ -45,7 +45,7 @@ const DEFAULT_RUN_MS = 900_000;
  * is killed by the CLIENT while the server is still working, surfacing as a bare
  * `TypeError: fetch failed`. The SDK tries to lift this (`req.timeout = false`) but that is a
  * Bun-ism: Bun honours it, Node ignores an unknown property on a WHATWG Request, and these
- * scripts run on node:22-slim.
+ * scripts run on Node (node:24-alpine3.24 in both recipes), not Bun.
  *
  * Bounded by the deadline rather than disabled outright, so the launcher's timeout_ms stays the
  * one authority on how long a run may take. Disabling it (headersTimeout: 0) would let a

--- a/sandbox-runner/agent-sandbox/template.ts
+++ b/sandbox-runner/agent-sandbox/template.ts
@@ -65,7 +65,13 @@ export const template = Template()
   // opencode-ai's and re2's install scripts below and ships an re2 that throws MODULE_NOT_FOUND
   // at require time.
   //
-  // git + the agent's clone; python3/py3-pip run the baked bundle validator;
+  // `apk upgrade` first, for the reason the sibling Dockerfile gives on this line: node:24-alpine3.24
+  // is rebuilt on Node's cadence, not Alpine's, so its openssl lags the 3.24 repo and is the only
+  // critical this recipe carries. NOTHING IS DELETED HERE, unlike launcher/Dockerfile, which drops
+  // npm and pnpm — this is a sandbox for agent code, so npm, python3, pip, git and the compilers
+  // are its runtime working surface rather than build-time bootstraps.
+  //
+  // Then the packages: git + the agent's clone; python3/py3-pip run the baked bundle validator;
   // make/g++/linux-headers build re2 FROM SOURCE (no prebuild for Node 24's ABI — see the header);
   // bash because THIS SDK execs /bin/bash and Alpine has none (see the header).
   // A raw runCmd, not `.aptInstall`, because the builder has no apkInstall — see the header.
@@ -73,7 +79,7 @@ export const template = Template()
   // (validate.py + pipeline_io.py, both of which `import yaml`) was previously a hard crash
   // in-VM, silently killing the observer's remediate+validate path. Install pip here and
   // PyYAML below.
-  .runCmd('apk add --no-cache bash git ca-certificates python3 py3-pip make g++ linux-headers', { user: 'root' })
+  .runCmd('apk upgrade --no-cache && apk add --no-cache bash git ca-certificates python3 py3-pip make g++ linux-headers', { user: 'root' })
   // PyYAML is the validator's only required third-party Python dep. Bake it at build time (no
   // per-run network install). --break-system-packages: Alpine's python3, like Debian's, marks the
   // system environment PEP 668 externally-managed; PIP_BREAK_SYSTEM_PACKAGES below lets the agent

--- a/sandbox-runner/agent-sandbox/template.ts
+++ b/sandbox-runner/agent-sandbox/template.ts
@@ -12,8 +12,10 @@ import { Template } from 'e2b';
  * Build/publish with the sibling build.ts (see README): `pnpm exec tsx build.ts`.
  *
  * BASE IMAGE PARITY: this template and the sibling Dockerfile (the Docker-backend agent
- * image) both compile re2@1.26.1, whose engines range starts at node 22.22.2. Both are
- * node:22-alpine3.24 for that one reason. Do not bump one without the other.
+ * image) both compile re2@1.26.1, whose engines range is "^22.22.2 || ^24.15.0 || >=26.0.0". Both
+ * are node:24-alpine3.24. Do not bump one without the other — and note that on 24 re2 has no
+ * prebuild for its ABI and builds from source, which is why `linux-headers` is in the apk line
+ * below and in the sibling's. See the sibling Dockerfile's header for the full account.
  *
  * ALPINE, AND THE TWO THINGS IT FORCES. E2B supports Alpine as a base (their docs list
  * Debian/Ubuntu, Fedora/RHEL, Arch and Alpine; only images with no /etc/os-release — scratch,
@@ -35,10 +37,13 @@ import { Template } from 'e2b';
  * build can never surface it, so re-run build.ts after touching any runCmd below.
  */
 export const template = Template()
-  // node 22, not 20: re2@1.26.1 (pinned below, byte-identical to the sibling Dockerfile) declares
-  // engines.node "^22.22.2 || ^24.15.0 || >=26.0.0", and npm's resolved node-gyp fails to even
-  // configure under Node 20 (`TypeError: webidl.util.markAsUncloneable is not a function`,
-  // verified on linux/amd64 and linux/arm64). The E2B build was unbuildable on 20.
+  // node 24, not 22: 22 is maintenance-only since 2025-10-21 and EOL 2027-04-30, 24 runs to
+  // 2028-04-30. re2@1.26.1 (pinned below, byte-identical to the sibling Dockerfile) declares
+  // engines.node "^22.22.2 || ^24.15.0 || >=26.0.0", so 24 is in range; 20 never was — npm's
+  // resolved node-gyp fails to even configure there (`TypeError:
+  // webidl.util.markAsUncloneable is not a function`, verified on linux/amd64 and linux/arm64),
+  // and the E2B build was unbuildable on 20. What 24 costs: re2 ships no prebuild for ABI 137, so
+  // it compiles from source and the apk line below must carry `linux-headers`.
   //
   // Alpine, not Debian: every CRITICAL left on the Debian recipe was an unfixable Debian package.
   // bookworm carried 16; trixie cleared libsqlite3-0 and zlib1g and left 13 — all perl
@@ -49,27 +54,26 @@ export const template = Template()
   // Dockerfile's fully built image with `trivy image`: 13 CRITICAL -> 0. `fromImage` rather than
   // `fromAlpineImage('3.24')` so this line stays a literal tag the sibling Dockerfile's FROM can
   // be diffed against; the two resolve to the same base.
-  .fromImage('node:22-alpine3.24')
-  // The `tar` module npm vendors (usr/local/lib/node_modules/npm/node_modules/tar) ships at
-  // 7.5.11 here — unaffected by the base-distro choice above, since it's npm's own payload, not an
-  // apt package — which carries CRITICAL CVE-2026-59873 (gzip-bomb DoS), fixed at tar@7.5.19.
-  // Patch the vendored copy in place rather than bumping npm itself: npm>=12 (the first release
-  // vendoring a fixed tar) flips `allowScripts` off by default, which would silently skip
-  // opencode-ai's and re2's install scripts below — shipping an re2 that throws MODULE_NOT_FOUND
-  // at require time. Verified: npm stays 10.9.8, the vendored tar reads 7.5.19, and `npm install`
-  // still runs afterward.
-  .runCmd(
-    'npm install -g tar@7.5.19 --prefix /tmp/tarfix && cp -r /tmp/tarfix/lib/node_modules/tar/* /usr/local/lib/node_modules/npm/node_modules/tar/ && rm -rf /tmp/tarfix && npm cache clean --force',
-    { user: 'root' },
-  )
-  // git + the agent's clone; python3/py3-pip run the baked bundle validator; make/g++ build re2
-  // (a native addon); bash because THIS SDK execs /bin/bash and Alpine has none (see the header).
+  .fromImage('node:24-alpine3.24')
+  // NO TAR PATCH HERE ANY MORE, and it should not come back — the sibling Dockerfile dropped the
+  // same step in the same commit. It used to copy tar@7.5.19 over the copy npm vendors at
+  // usr/local/lib/node_modules/npm/node_modules/tar, because node:22-alpine3.24's npm 10.9.8
+  // vendored 7.5.11 and carried CRITICAL CVE-2026-59873 (gzip-bomb DoS). node:24-alpine3.24 ships
+  // npm 11.19.0, whose vendored tar is already 7.5.19 — verified on the base — so the step became
+  // a no-op the moment `fromImage` above moved. If it ever recurs, patch the vendored copy again
+  // rather than bumping npm: npm>=12 flips `allowScripts` off by default, which silently skips
+  // opencode-ai's and re2's install scripts below and ships an re2 that throws MODULE_NOT_FOUND
+  // at require time.
+  //
+  // git + the agent's clone; python3/py3-pip run the baked bundle validator;
+  // make/g++/linux-headers build re2 FROM SOURCE (no prebuild for Node 24's ABI — see the header);
+  // bash because THIS SDK execs /bin/bash and Alpine has none (see the header).
   // A raw runCmd, not `.aptInstall`, because the builder has no apkInstall — see the header.
   // NOTE: the base's python3 ships WITHOUT pip and WITHOUT PyYAML, so the validator
   // (validate.py + pipeline_io.py, both of which `import yaml`) was previously a hard crash
   // in-VM, silently killing the observer's remediate+validate path. Install pip here and
   // PyYAML below.
-  .runCmd('apk add --no-cache bash git ca-certificates python3 py3-pip make g++', { user: 'root' })
+  .runCmd('apk add --no-cache bash git ca-certificates python3 py3-pip make g++ linux-headers', { user: 'root' })
   // PyYAML is the validator's only required third-party Python dep. Bake it at build time (no
   // per-run network install). --break-system-packages: Alpine's python3, like Debian's, marks the
   // system environment PEP 668 externally-managed; PIP_BREAK_SYSTEM_PACKAGES below lets the agent
@@ -106,7 +110,7 @@ export const template = Template()
   // nothing, and npm is already in the base image while pnpm would be another install step.
   // undici pins to ^6 ON PURPOSE: byte-identical to the sibling Dockerfile's install line so the
   // recipes for this one runtime never drift (see the header). 6.x declares node >=18.17 with no
-  // upper bound. undici 8 (node >=22.19) would work on node:22-alpine3.24 but must be bumped everywhere
+  // upper bound. undici 8 (node >=22.19) would work on node:24-alpine3.24 but must be bumped everywhere
   // together: here, the sibling Dockerfile, AND agent-sandbox/package.json (the host-local
   // backend, also ^6.28.0). agent-stream.js needs it to lift fetch's 300s headers timeout.
   .runCmd(

--- a/sandbox-runner/launcher/Dockerfile
+++ b/sandbox-runner/launcher/Dockerfile
@@ -26,6 +26,13 @@
 FROM node:24-alpine3.24
 
 WORKDIR /app
+# node:24-alpine3.24 is rebuilt on Node's release cadence, not Alpine's, so its openssl
+# (libcrypto3/libssl3) lags whatever is current in the 3.24 repo — the only criticals this image
+# has ever carried. Upgrading here rather than pinning a base image is the trade this repo makes
+# knowingly: two builds a week apart can resolve different package versions, which costs exact
+# reproducibility and buys not waiting on someone else's release schedule. Mirrored in
+# agent-sandbox's own apk line.
+RUN apk upgrade --no-cache
 # Global install rather than corepack — see frontend/Dockerfile. PNPM_VERSION comes from the build
 # orchestrator (Taskfile `PNPM_VERSION` locally; the `PNPM_VERSION` Actions variable in CI); the
 # default is the same pin, held equal by scripts/check-required-inputs.sh.
@@ -46,6 +53,24 @@ RUN pnpm install --frozen-lockfile --prod
 # and needs no overrides.)
 
 COPY server.js ./
+
+# Both package managers are build-time bootstraps and neither survives into the runtime: the
+# install above is done, and CMD is `node server.js`. They are the only things in this image that
+# vendor a copy of node-tar, which is where every HIGH it has carried has come from — npm vendors
+# one at /usr/local/lib/node_modules/npm/node_modules/tar and pnpm vendors two more under its own
+# dist/. Deleting them is strictly better than the version pin this line replaces (see the
+# npm@12.0.2 note above, removed in the Node 24 commit): a pin has to be re-chased every time the
+# advisory feed moves past it — that pin was already stale, reaching a tar 7.5.19 that has since
+# picked up a finding of its own — where a deleted package cannot acquire a new CVE.
+#
+# This is a LATER LAYER, so it clears the scanner without reclaiming the bytes; the earlier layers
+# still hold them. Merging it into the install layer would save the space but would also mean
+# deleting npm in the same RUN that uses it. Correctness first; the image is not size-critical.
+RUN rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/lib/node_modules/pnpm \
+           /usr/local/lib/node_modules/corepack \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx /usr/local/bin/pnpm \
+             /usr/local/bin/pnpx /usr/local/bin/corepack
 
 # The image's version identity, same convention and same "dev" fallback as
 # backend/Dockerfile, so the release workflow's OCI

--- a/sandbox-runner/launcher/Dockerfile
+++ b/sandbox-runner/launcher/Dockerfile
@@ -1,9 +1,13 @@
 # Launcher sidecar image. Holds the E2B SDK + the E2B_API_KEY (env); never runs
 # untrusted grader code itself — it only orchestrates microVMs.
 #
-# Node 22, not 20: pnpm 11 requires node >=22.13 and dies on 20 with ERR_UNKNOWN_BUILTIN_MODULE.
-# Matches the nodejs22.x Lambda runtime; server.js is plain ESM-free CommonJS over the e2b SDK,
-# with nothing 20-specific to lose.
+# Node 24, not 22: 22 has been maintenance-only since 2025-10-21 and is EOL 2027-04-30, where 24
+# runs to 2028-04-30. The floor that used to justify this line still holds and is not the reason
+# for it — pnpm 11 requires node >=22.13 and dies on 20 with ERR_UNKNOWN_BUILTIN_MODULE — so
+# package.json's `engines` stays at >=22.13: that is what server.js CAN run on, not what we ship.
+# server.js is plain ESM-free CommonJS over the e2b SDK with nothing major-specific either way.
+# (The nodejs22.x Lambda runtime this used to match is gone; the SandboxRunner Lambda
+# implementation was removed along with grading — see devdocs/reference/architecture.md.)
 #
 # ALPINE, not Debian. Every CRITICAL this image carried was an unfixable Debian package:
 # bookworm gave 4 (zlib1g CVE-2023-45853, "will_not_fix", plus 3 perl-base), trixie cleared the
@@ -15,29 +19,26 @@
 # Nothing here is exposed to musl risk: the sole runtime dependency (e2b) is pure JS, there is no
 # native addon, no python and no compiler. This matches sandbox-runner/agent-sandbox/Dockerfile
 # and its template.ts twin, which moved to Alpine at the same time.
-# NOTE this is no longer classify-service's base (that one is still node:22-slim); it was, and the
-# divergence is deliberate, not drift.
-FROM node:22-alpine3.24
+# NOTE this is no longer classify-service's base (that one is node:24-slim — same Node major since
+# the 22->24 bump, still Debian). The remaining divergence is deliberate, not drift:
+# classify-service needs glibc for onnxruntime-node's and sharp's prebuilt binaries, which is
+# exactly the musl exposure this image has none of.
+FROM node:24-alpine3.24
 
 WORKDIR /app
 # Global install rather than corepack — see frontend/Dockerfile. PNPM_VERSION comes from the build
 # orchestrator (Taskfile `PNPM_VERSION` locally; the `PNPM_VERSION` Actions variable in CI); the
 # default is the same pin, held equal by scripts/check-required-inputs.sh.
 ARG PNPM_VERSION=11.15.1
-# npm@12.0.2 pinned alongside pnpm to clear CVE-2026-59873 (node-tar, bundled inside npm's own
-# node_modules, not an app dependency): the base's stock npm 10.9.8 bundles tar 7.5.11, and no npm
-# release before 12.0.0 bundles the fixed tar 7.5.19. npm is only a build-time bootstrap here
-# (never invoked again — the line below installs with pnpm, and CMD is `node server.js`), so this
-# has no runtime effect. The cache clean is size only: npm otherwise leaves ~38 MB in ~/.npm that
-# nothing at runtime reads.
-#
-# The agent-sandbox recipes fix the SAME CVE a different way (they overwrite npm's vendored tar in
-# place and leave npm at 10.9.8) and that asymmetry is deliberate: npm >=12 defaults `allowScripts`
-# off, so under npm 12 `npm install re2@^1.26.1` completes with a warning but never runs re2's
-# node-gyp build, leaving a package that throws MODULE_NOT_FOUND on require. Verified directly on
-# node:22-trixie-slim and again on node:22-alpine3.24. This image installs with pnpm and compiles no native addon, so npm 12 is
-# safe HERE and only here. Do not copy this line into agent-sandbox.
-RUN npm i -g npm@12.0.2 pnpm@${PNPM_VERSION} \
+# npm is a build-time bootstrap only — the line below installs with pnpm and CMD is
+# `node server.js`. THE npm@12.0.2 PIN THAT USED TO BE ON THIS LINE IS GONE AND SHOULD NOT COME
+# BACK: it existed to clear CVE-2026-59873 (node-tar, vendored inside npm's own node_modules, not
+# an app dependency) because node:22-alpine3.24's stock npm 10.9.8 vendored tar 7.5.11 and no npm
+# before 12.0.0 vendored the fixed 7.5.19. node:24-alpine3.24 ships npm 11.19.0, whose vendored tar
+# is already 7.5.19, so the pin now buys nothing and only costs the `allowScripts` hazard that made
+# it unsafe to copy into agent-sandbox. The cache clean is size only: npm otherwise leaves ~38 MB
+# in ~/.npm that nothing at runtime reads.
+RUN npm i -g pnpm@${PNPM_VERSION} \
     && npm cache clean --force
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile --prod


### PR DESCRIPTION
Takes the four published images from **13 critical vulnerabilities to 2**, and 69 highs to 33, without swapping a single base image or changing anything a self-hoster touches.

Three commits, meant to be read in order.

## 1. `8bcaa44` — every Node image from 22 to 24

Node 22 has been maintenance-only since 2025-10-21 and is EOL 2027-04-30; 24 runs to 2028-04-30. Three places were already on 24 (the frontend build stage, its dev image, `check.yml`'s `node-version`, and the toolchain image), so this only moves what was left: both `sandbox-runner` recipes and `classify-service`.

`re2@1.26.1` declares `engines.node: "^22.22.2 || ^24.15.0 || >=26.0.0"`, so 24 was always in range — the constraint documented in agent-sandbox's header ruled out Node 20, not 24.

**What it costs.** re2 publishes prebuilt binaries per Node ABI. Node 22 is ABI 127 and has a musl prebuild; 24 is ABI 137 and does not, so re2 now compiles from source and needs `linux-headers` for abseil's `direct_mmap.h`. Added to the apk line in both recipes. That layer goes from seconds to ~3.5 min — and the source path is ABI-agnostic, so the next Node bump no longer waits on upstream prebuilds.

**What it pays for.** `node:24-alpine3.24` ships npm 11.19.0, whose vendored tar is already 7.5.19 — exactly the version both existing workarounds existed to reach. Both are deleted here:

- agent-sandbox (Dockerfile + template.ts) hand-copied `tar@7.5.19` over npm's vendored copy to clear CVE-2026-59873.
- launcher pinned `npm@12.0.2` for the same CVE, carrying the `allowScripts` hazard that made the line unsafe to share with agent-sandbox.

Both comments now record why they are gone and what to do if it recurs.

## 2. `08d5665` — upgrade what we run, delete what we don't

Two different moves, applied per image, with the reasoning recorded in place.

**Upgrade** (openssl, all three Alpine images). `caddy:2-alpine` and `node:24-alpine3.24` are rebuilt on their upstream's cadence, not Alpine's, so both lag the patched openssl already sitting in the Alpine repo. `apk upgrade --no-cache` closes CVE-2026-63073 and CVE-2026-75803.

**Delete** (things nothing here runs):

| image | deleted | why |
|---|---|---|
| frontend | `curl`, `libcurl` | Caddy is a static Go binary on `crypto/tls` that never links libcurl; the healthcheck uses busybox wget |
| sandbox-runner | `npm`, `pnpm`, `corepack` | build-time bootstraps only — `CMD` is `node server.js`. They were the sole vendors of node-tar, the source of every HIGH this image carried |
| agent-sandbox | **nothing** | npm, python3, pip, git and the compilers are this sandbox's runtime working surface for agent code |
| backend | `/usr/bin/pebble` | Canonical's service manager, baked into Ubuntu 26.04, built with Go 1.26.5 (CVE-2026-39821). Nothing starts it |

Deleting is preferred over pinning wherever it reaches: the `npm@12.0.2` pin this replaces was already stale, having reached a tar 7.5.19 that has since picked up a finding of its own. A deleted package cannot acquire a new CVE.

## 3. `52bb262` — two comment corrections from the release audit

No behaviour change. The `apk del` note claimed a three-package cascade; it is nine. `agent-stream.js` still claimed `node:22-slim`.

## Results

Measured on images built from this branch, **both architectures**:

| image | before | after |
|---|---|---|
| frontend | 8C 33H | 1C 13H |
| sandbox-runner | 2C 12H | **0C 0H 0M 0L** |
| agent-sandbox | 2C 19H | 0C 7H |
| backend | 1C 5H | 1C 5H |

## What a reviewer should know

**Verified, not just scanned.** Services were started and exercised: the frontend serves with SPA fallback, proxies `/api`, still negotiates gzip and passes its healthcheck on busybox wget with curl gone; the launcher answers `/healthz` with npm/pnpm/corepack deleted; the backend boots Spring on Java 25 as uid 999. `linux/amd64` and `linux/arm64` both build and resolve to identical package versions, and the opencode inode-prune correctly keeps one variant on each — including amd64, where the header warns a name-based prune misses the `-baseline` flavours.

`check-required-inputs.sh`, `check-version-consistency.sh` and `check-license-headers.sh` all exit 0.

**The trade this makes knowingly.** `apk upgrade` means two builds a week apart can resolve different package versions — exact reproducibility traded for not waiting on someone else's release schedule. An audit raised the BuildKit-cache objection (does a restored layer silently skip the upgrade?) and it was refuted by rebuilding from a cold cache: the restored layer *is* the upgraded filesystem diff, and the floating base tags turn the cache key over whenever upstream rebuilds.

**Two findings deliberately left.** Caddy's own binary was built with Go 1.26.3 — it cannot be upgraded by a package manager and cannot be deleted, since it is the web server; replacing it with nginx would zero the finding but cost self-hosters Caddy's automatic HTTPS. And on the backend, the pebble deletion removes the reachable risk but not the reported count: no ELF on the built filesystem carries a `go1.x` build stamp, yet Scout still reports it, attributing from the base image it auto-detects. Winning that number back would mean flattening the image and destroying the layered-jar cache ordering. Both are documented at the line.

## Not covered by this PR

- **`classify-service` has not been built.** It needs `HF_TOKEN` for private HF repos. It is outside the release path entirely — no reference in `release.yml`, and it appears in `docker-compose.yml` only in comments — so it cannot affect this release or a self-hoster, but it should be built once before the ECS deploy next runs. Its two native deps (`onnxruntime-node@1.24.3`, `sharp`) were verified to install and load on `node:24-slim`; both are N-API and therefore ABI-stable.
- **The E2B template has not been published.** `template.ts` type-checks, resolves to the intended step list, and its apk line is byte-identical to the sibling Dockerfile's — but `Template.build` needs a credential and overwrites the live `tessary-agent-sandbox` alias. `SANDBOX_BACKEND` defaults to `docker`, so the common path is fully covered; if anything runs the `e2b` backend, rebuild the template alongside this merge so the two recipes do not drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)