### PR TITLE
feat(release): ship the E2B agent template with the images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,12 @@ TESSARY_TELEMETRY_ENABLED=true
 # TESSARY_VERSION above; pin it alone only to run an image you built yourself. Not published until
 # a human dispatches .github/workflows/release.yml for the first time — "Run RCA" 502s until then.
 # AGENT_IMAGE=tessaryai/tessary:agent-sandbox-<version>
+#
+# The same agent runtime, for the OTHER backend. Only read when SANDBOX_BACKEND=e2b, and only
+# useful alongside your own E2B_API_KEY. The template is public, so your key can resolve it; the
+# `tessary/` prefix is the E2B project that publishes it and is not optional — a bare name resolves
+# only inside that project. Unset floats to `:latest`, which each release repoints.
+# E2B_ANALYZER_TEMPLATE=tessary/tessary-agent-sandbox:<version>
 
 # The GID granting the launcher container write access to the mounted /var/run/docker.sock. Read it
 # as a container sees the socket:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,17 @@
 # =============================================================================
-# Release: publish all four Tessary images
+# Release: publish all four Tessary images and the E2B agent template
 # =============================================================================
 # Builds and pushes all four images (backend, frontend, sandbox-runner, agent-sandbox) from one
-# dispatched bump. It is the only publisher in this repo.
+# dispatched bump, and publishes the E2B agent template alongside them. It is the only publisher in
+# this repo.
+#
+# FIVE ARTIFACTS, NOT FOUR, and the fifth is not a docker image. The agent runtime has TWO recipes:
+# sandbox-runner/agent-sandbox's Dockerfile (what SANDBOX_BACKEND=docker runs) and its template.ts
+# (an E2B cloud template, what SANDBOX_BACKEND=e2b runs). They are alternatives an install chooses
+# between, never a pair that reference each other — so publishing one without the other leaves half
+# the backends on a stale agent. Until build-agent-template existed the E2B half was a human step,
+# tied to no version at all: whatever the last hand-run `tsx build.ts` left behind. See that job's
+# own header for the recipe-hash mechanism, and verify-agent-template's for why it boots the thing.
 #
 # Registry: DOCKER HUB, and only Docker Hub (`tessaryai/tessary`) — every comparable self-hosted
 # OSS project checked ships its primary image there, and `docker pull org/image` with no registry
@@ -77,6 +86,13 @@
 # on 0.2.0 with the other three services carrying no `-latest` at all; this ordering is what makes
 # that state unreachable.
 #
+# THE E2B TEMPLATE SPLITS ALONG THE SAME LINE, and it is the clearest case of why the line is where
+# it is. `<version>` and `recipe-<hash>` are new tags nobody is using, so build-agent-template
+# writes them early and cleanup takes the version one away. `latest` and `default` are NOT new:
+# E2B resolves a bare `tessary-agent-sandbox` to `:default`, so both already point at the previous
+# release and moving them is not reversible by deleting anything. They move in finalize, next to
+# `<service>-latest`, for exactly that reason.
+#
 # THE TWO COMPOSE TAGS SPLIT ALONG THE SAME LINE, and this is the part that is easy to get wrong.
 # `compose-<version>` is new on every release, so it is version-scoped, deletable, and written
 # BEFORE the commit point by publish-compose — which is the whole point: if publishing does not
@@ -122,7 +138,12 @@
 # Required secrets:
 #   DOCKER_USERNAME  - Docker Hub username (for image push from runner)
 #   DOCKER_TOKEN     - Docker Hub access token (for image push from runner)
-# GHCR uses the built-in GITHUB_TOKEN (permissions.packages: write below).
+#   E2B_API_KEY      - the E2B team that owns tessary/tessary-agent-sandbox. OPTIONAL, and the only
+#                      optional one: a fork with no such key still publishes the four images, and
+#                      the two template jobs no-op with a warning. The gate is inside each step
+#                      rather than a job-level `if:` — `secrets` is not available in a job `if`, and
+#                      a SKIPPED job skips everything that `needs:` it, which would silently take
+#                      publish-compose and finalize down with it.
 #
 # NO REPO VARIABLE, AND NO SECOND INPUT OF ANY KIND: the dispatch bump is the only thing a human
 # supplies. pnpm used to arrive here as a `PNPM_VERSION` Actions variable, which was a THIRD copy
@@ -484,6 +505,117 @@ jobs:
           retention-days: 1
 
   # ---------------------------------------------------------------------------------------------
+  # THE E2B LANE. The agent runtime has TWO recipes, not one: sandbox-runner/agent-sandbox's
+  # Dockerfile (built by build-agent-sandbox above, what SANDBOX_BACKEND=docker runs) and its
+  # template.ts (an E2B cloud template, what SANDBOX_BACKEND=e2b runs). They are alternatives an
+  # install chooses between, never a pair that reference each other — so a release that ships one
+  # and not the other leaves half the backends on a stale agent.
+  #
+  # Until this job existed the E2B half was a HUMAN STEP: somebody with the team's key ran
+  # `pnpm exec tsx build.ts` and the published template was whatever that last run left behind,
+  # tied to no version at all.
+  #
+  # ADDITIVE, LIKE EVERY OTHER JOB ABOVE FINALIZE. It writes `<version>` and `recipe-<hash>`, both
+  # new, both removable by cleanup. It writes NEITHER `latest` NOR `default` — E2B resolves a bare
+  # `tessary-agent-sandbox` to `:default`, so both of those already point at the previous release
+  # and moving them is finalize's, for exactly the reason `<service>-latest` is.
+  #
+  # "IF IT HAS CHANGED" IS ANSWERED BY E2B, NOT BY GIT. build.ts hashes the real build inputs
+  # (template.ts, the three agent scripts, the validator wrapper, the five contract/ files, the
+  # cpu/memory pair) and carries the digest as a `recipe-<hash>` tag. A build already wearing this
+  # release's hash gets the version tag assigned to it and no rebuild happens. A `git diff` against
+  # the base tag would answer the same question about the SOURCE and be wrong in the one case that
+  # matters: after a release whose template build failed, the source is unchanged at the next
+  # attempt, so a diff would skip the rebuild and stamp a version onto a template that never got
+  # the change.
+  #
+  # SKIPPED, NOT FAILED, WITHOUT THE SECRET. A fork has no E2B_API_KEY and must still be able to
+  # dispatch a release of the four images. The gate is inside the step rather than a job-level
+  # `if:` on purpose — `secrets` is not available in a job `if`, and a job that SKIPS would skip
+  # every job that `needs:` it, silently taking publish-compose and finalize with it.
+  build-agent-template:
+    name: Build the E2B agent template
+    runs-on: ubuntu-24.04
+    needs: preflight
+    outputs:
+      rebuilt: ${{ steps.release.outputs.rebuilt }}
+      recipe: ${{ steps.release.outputs.recipe }}
+      build_id: ${{ steps.release.outputs.build_id }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # Must precede setup-node: its `cache: pnpm` shells out to pnpm to resolve the store path.
+      - uses: pnpm/action-setup@v6
+        with:
+          package_json_file: sandbox-runner/agent-sandbox/package.json
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: pnpm
+          cache-dependency-path: sandbox-runner/agent-sandbox/pnpm-lock.yaml
+      # --ignore-scripts, and it is not a hardening flourish: this manifest carries re2, a native
+      # addon whose install script runs node-gyp. build.ts needs e2b and tsx and nothing else —
+      # the modules with build steps are baked INTO the template, never imported by the publisher.
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+        working-directory: sandbox-runner/agent-sandbox
+
+      - id: release
+        working-directory: sandbox-runner/agent-sandbox
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${E2B_API_KEY:-}" ]; then
+            echo "::warning::E2B_API_KEY is not set, so the E2B template lane is skipped. The four" \
+                 "images still publish; SANDBOX_BACKEND=e2b installs keep resolving the previous build."
+            exit 0
+          fi
+          pnpm exec tsx build.ts --release="${{ needs.preflight.outputs.version }}" \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------------------------
+  # THE ONE GATE NO IMAGE BUILD CAN STAND IN FOR, and template.ts's own header is the argument:
+  # this SDK hardcodes `cmd: "/bin/bash"` (Alpine ships busybox ash and no bash), and E2B's runCmd
+  # is NOT root where Docker's RUN is. Either mistake produces a template that BUILDS CLEANLY and
+  # then fails on every single run — invisible to `docker build`, invisible to review, and last
+  # time it was caught by an actual boot rather than by reading. So the release boots the thing it
+  # just tagged and runs commands through it.
+  #
+  # IT RUNS ON THE DEDUP PATH TOO. "The recipe did not change" is a statement about this
+  # repository; it is not evidence that the published build still resolves and boots.
+  #
+  # It also asserts the template is still PUBLIC and still spells its namespaced name the way this
+  # repo does. E2B namespaces a template by project slug, so `tessary/tessary-agent-sandbox` is
+  # what a self-hoster's own key must resolve — a console toggle flipped back to private would
+  # otherwise be discovered by them, on their first /rca, rather than here.
+  verify-agent-template:
+    name: Boot the E2B template and prove it runs
+    runs-on: ubuntu-24.04
+    needs: [preflight, build-agent-template]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@v6
+        with:
+          package_json_file: sandbox-runner/agent-sandbox/package.json
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: pnpm
+          cache-dependency-path: sandbox-runner/agent-sandbox/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+        working-directory: sandbox-runner/agent-sandbox
+
+      - working-directory: sandbox-runner/agent-sandbox
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${E2B_API_KEY:-}" ]; then
+            echo "::warning::E2B_API_KEY is not set; nothing was published to E2B, so there is nothing to verify."
+            exit 0
+          fi
+          pnpm exec tsx build.ts --verify="${{ needs.preflight.outputs.version }}"
+
+  # ---------------------------------------------------------------------------------------------
   # No published artifact reaches a real tag with excluded content in it. The four
   # arch-suffixed images above are the artifacts; this job pulls the amd64 build of each and diffs
   # its exported contents against scripts/lib/open-artifact-denylist.txt. It sits BETWEEN the
@@ -630,7 +762,11 @@ jobs:
     # THE PINNED TAG ONLY, and BEFORE finalize — see the header. Writing `compose-<version>` here is
     # what proves publishing works while the run is still reversible; the floating `compose` alias
     # is finalize's, because deleting a floating alias is an outage rather than a rollback.
-    needs: [preflight, merge-manifests, verify-manifests]
+    #
+    # verify-agent-template is in this list for the same reason verify-manifests is: the config
+    # published here pins E2B_ANALYZER_TEMPLATE to `tessary/tessary-agent-sandbox:<version>`, so
+    # that tag must exist and boot before anything hands a self-hoster a file naming it.
+    needs: [preflight, merge-manifests, verify-manifests, verify-agent-template]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
@@ -671,6 +807,10 @@ jobs:
                 printf '%s\n' "$rendered" | grep -qF "tessaryai/tessary:${service}-${VERSION}" || {
                   echo "::error::oci://${repo}:${tag} does not pin ${service} to ${VERSION}" >&2; exit 1; }
               done
+              # The E2B template is the fourth pinned reference and the only one that is not a
+              # docker ref, so no loop above would notice it staying floating.
+              printf '%s\n' "$rendered" | grep -qF "tessary/tessary-agent-sandbox:${VERSION}" || {
+                echo "::error::oci://${repo}:${tag} does not pin the E2B template to ${VERSION}" >&2; exit 1; }
               printf '%s\n' "$rendered" | grep -E '^ +source: /' | grep -vE 'source: /(var/run/docker.sock|proc|sys)$' && {
                 echo "::error::oci://${repo}:${tag} carries a host-path bind" >&2; exit 1; } || true
               echo "OK: ${repo}:${tag} renders, pins ${VERSION}, mounts no host path"
@@ -691,7 +831,7 @@ jobs:
   finalize:
     name: Repoint -latest and compose, push the release tag
     runs-on: ubuntu-24.04
-    needs: [preflight, merge-manifests, verify-manifests, publish-compose]
+    needs: [preflight, merge-manifests, verify-manifests, verify-agent-template, publish-compose]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
@@ -712,6 +852,34 @@ jobs:
               -t "${{ env.DOCKER_REPO }}:${service}-latest" \
               "${{ env.DOCKER_REPO }}:${service}-${VERSION}"
           done
+
+      # THE E2B TEMPLATE'S FLOATING TAGS, and they belong here for the same reason `-latest` does.
+      # `latest` is what docker-compose.yml's `${TESSARY_VERSION:-latest}` default resolves to;
+      # `default` is what a BARE `tessary-agent-sandbox` means to E2B, which is what every config
+      # written before this lane existed says. Both move together, onto the build
+      # build-agent-template tagged and verify-agent-template booted, so the two spellings cannot
+      # come to disagree about which build is current.
+      - uses: pnpm/action-setup@v6
+        with:
+          package_json_file: sandbox-runner/agent-sandbox/package.json
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          cache: pnpm
+          cache-dependency-path: sandbox-runner/agent-sandbox/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+        working-directory: sandbox-runner/agent-sandbox
+      - name: Repoint the E2B template's latest and default tags
+        working-directory: sandbox-runner/agent-sandbox
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${E2B_API_KEY:-}" ]; then
+            echo "::warning::E2B_API_KEY is not set; nothing was published to E2B, so there is nothing to repoint."
+            exit 0
+          fi
+          pnpm exec tsx build.ts --promote="${{ needs.preflight.outputs.version }}"
 
       # The floating alias, now that `-latest` resolves to this release. publish-compose already
       # wrote `compose-<version>` from the identical file and proved it renders, so this cannot be
@@ -743,6 +911,8 @@ jobs:
             printf '%s\n' "$rendered" | grep -qF "tessaryai/tessary:${service}-${VERSION}" || {
               echo "::error::${REF} does not pin ${service} to ${VERSION}" >&2; exit 1; }
           done
+          printf '%s\n' "$rendered" | grep -qF "tessary/tessary-agent-sandbox:${VERSION}" || {
+            echo "::error::${REF} does not pin the E2B template to ${VERSION}" >&2; exit 1; }
           echo "OK: ${REF} renders and pins ${VERSION}"
 
       - name: Create and push the release tag
@@ -813,6 +983,8 @@ jobs:
       - build-frontend
       - build-sandbox-runner
       - build-agent-sandbox
+      - build-agent-template
+      - verify-agent-template
       - verify-open-artifacts
       - merge-manifests
       - verify-manifests
@@ -862,3 +1034,31 @@ jobs:
               *)   echo "::warning::could not delete ${tag} (HTTP ${code}; a token without Delete scope answers 403)" ;;
             esac
           done
+
+      # THE E2B HALF OF THE SAME ROLLBACK. Curl rather than `tsx build.ts --rollback`, deliberately:
+      # this job must never turn one failure into a confusing second one, and a toolchain setup is
+      # three more ways to fail while reporting nothing useful. One request, same shape as the
+      # Docker Hub deletes above.
+      #
+      # ONLY THE VERSION TAG GOES. `recipe-<hash>` stays on purpose — it names a build by its
+      # CONTENTS, so it cannot come to mean the wrong thing, and leaving it is what lets the next
+      # attempt at this release skip a template build it already paid for.
+      - name: Remove the E2B version tag this run created
+        env:
+          E2B_API_KEY: ${{ secrets.E2B_API_KEY }}
+          VERSION: ${{ needs.preflight.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${E2B_API_KEY:-}" ] || [ -z "$VERSION" ]; then
+            echo "no E2B key or no version; nothing was tagged on E2B, nothing to remove."
+            exit 0
+          fi
+          code="$(curl -s -o /dev/null -w '%{http_code}' -X DELETE \
+            -H "X-API-KEY: $E2B_API_KEY" -H 'Content-Type: application/json' \
+            -d "$(jq -nc --arg v "$VERSION" '{name:"tessary-agent-sandbox",tags:[$v]}')" \
+            https://api.e2b.dev/templates/tags)"
+          case "$code" in
+            20*) echo "deleted  e2b tag ${VERSION}" ;;
+            404) echo "absent   e2b tag ${VERSION}" ;;
+            *)   echo "::warning::could not delete the E2B tag ${VERSION} (HTTP ${code})" ;;
+          esac

--- a/devdocs/guides/upgrade-contract.md
+++ b/devdocs/guides/upgrade-contract.md
@@ -112,11 +112,10 @@ For every layout-level change, touch each of these in order:
    bakes the contract files into the sandbox image from this repo's `contract/` (staged into
    `vendor/` by `build.ts`). The two lanes that run there — RCA and Layer-2 triage — READ the
    bundle to ground a ruling; neither writes one back, so a version skew now fails a comparison
-   rather than corrupting a repo. It still wants a rebuild on a contract bump: `cd
-   sandbox-runner/agent-sandbox && pnpm install && pnpm exec tsx build.ts` (needs the prod
-   team's `E2B_API_KEY`). **The template must exist under the name `tessary-agent-sandbox` before
-   any E2B-backed deploy** — nothing in this repo can create the
-   cloud template.
+   rather than corrupting a repo. **A contract bump no longer needs a manual rebuild**: the five
+   `contract/` files are inputs to `build.ts`'s recipe hash, so the next release notices they moved
+   and rebuilds the template on its own. Nothing to remember, and nothing to forget — which is what
+   the old instruction here was relying on.
 
 ### 4. Verify
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -396,7 +396,9 @@ services:
       # Must equal the backend's TESSARY_OBSERVER_AGENTIC_LAUNCHER_API_KEY.
       SANDBOX_API_KEY: ${TESSARY_OBSERVER_AGENTIC_LAUNCHER_API_KEY:-}
       E2B_API_KEY: ${E2B_API_KEY:-}
-      E2B_ANALYZER_TEMPLATE: ${E2B_ANALYZER_TEMPLATE:-tessary-agent-sandbox}
+      # Namespaced and floating, exactly as docker-compose.yml's sandbox-runner service — see the
+      # comment there for why the bare name was unreachable outside the Tessary E2B project.
+      E2B_ANALYZER_TEMPLATE: ${E2B_ANALYZER_TEMPLATE:-tessary/tessary-agent-sandbox:${TESSARY_VERSION:-latest}}
       # FULL REMOVAL of every deployment-env-var credential this service used to read —
       # AWS_REGION/AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/MANTLE_REGION, the whole AGENT_PROVIDER
       # dev-override block (ANTHROPIC_API_KEY, AWS_BEARER_TOKEN_BEDROCK, OPENAI_API_KEY,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -542,7 +542,14 @@ services:
       # the name verbatim.
       SANDBOX_WORK_VOLUME: ${SANDBOX_WORK_VOLUME:-tessary-sandbox-work}
       E2B_API_KEY: ${E2B_API_KEY:-}
-      E2B_ANALYZER_TEMPLATE: tessary-agent-sandbox
+      # NAMESPACED, AND VERSIONED, for the same reason AGENT_IMAGE above is both. E2B scopes a
+      # template name to the project that built it, so the bare `tessary-agent-sandbox` this used
+      # to say resolved ONLY for a key belonging to the Tessary team — a self-hoster who set
+      # SANDBOX_BACKEND=e2b with their own key got `Sandbox.create` finding nothing. The template
+      # is published public; `tessary/…` is the form anyone's key can reach.
+      # Unset floats to `:latest`, which release.yml's finalize repoints; the version lives in the
+      # git tag, never in a literal here.
+      E2B_ANALYZER_TEMPLATE: ${E2B_ANALYZER_TEMPLATE:-tessary/tessary-agent-sandbox:${TESSARY_VERSION:-latest}}
       # FULL REMOVAL of every deployment-env-var credential the launcher used to read
       # here — AWS_REGION/AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/MANTLE_REGION, the whole
       # AGENT_PROVIDER dev-override block (ANTHROPIC_API_KEY, AWS_BEARER_TOKEN_BEDROCK,

--- a/sandbox-runner/README.md
+++ b/sandbox-runner/README.md
@@ -25,12 +25,14 @@ Three whole subtrees went with them: `lambda/` (the AWS Lambda grading executor 
 `codegen.js` / `codegen-harness.js` / `synthesize.js` / `analyze.js` scripts under
 `agent-sandbox/`. `deploy-grader-lambda.yml` went with the first of those.
 
-**Two E2B cloud templates are affected and only one is rebuilt by this repo.** The analyzer template
-was republished under the alias `tessary-agent-sandbox` (was `evals-observer-analyzer`) — a human
-with the team's E2B key must run the build in `agent-sandbox/` before any e2b-backed deploy, or
-`Sandbox.create` resolves nothing and both surviving routes fail on their first call. The grader
-template's alias, `evals-grader-runner`, is simply orphaned in E2B; nothing in this tree can delete
-it.
+**Two E2B cloud templates are affected and only one is built by this repo.** The analyzer template
+was republished under the name `tessary-agent-sandbox` (was `evals-observer-analyzer`) and is
+**published public**, so it is reachable as `tessary/tessary-agent-sandbox` by any E2B key rather
+than only the team's. Building it is **no longer a human step**: `.github/workflows/release.yml`
+publishes it from the same dispatch that publishes the four images, tags it with the release's
+version, boots it to prove it runs, and repoints its floating tags in finalize — see
+[Deploy](#deploy) below. The grader template's alias, `evals-grader-runner`, is simply orphaned in
+E2B; nothing in this tree can delete it.
 
 ## Layout
 
@@ -74,22 +76,45 @@ The launcher ships as its own image, built and pushed by
 `launcher/Dockerfile`, and runs as the `sandbox-runner` service in both compose files. The backend
 reaches it by service DNS at `http://sandbox-runner:8080` and authenticates with `SANDBOX_API_KEY`.
 
-The E2B backend additionally needs the analyzer template published under the alias the launcher
-expects. **This is a human step and this repo cannot do it** (it needs the team's E2B key):
+The E2B backend's template is published by that same workflow, from the `E2B_API_KEY` repository
+secret, in two jobs either side of the commit point:
+
+| job | writes | undone by |
+|---|---|---|
+| `build-agent-template` | `<version>` and `recipe-<hash>` — and **only builds if the recipe changed** | `cleanup` |
+| `verify-agent-template` | nothing; boots `tessary/tessary-agent-sandbox:<version>` and runs seven checks through it | n/a |
+| `finalize` | moves `latest` and `default` onto that build | nothing (this is the commit point) |
+
+`recipe-<hash>` is a digest of the real build inputs — `template.ts`, the three agent scripts, the
+validator wrapper, the five `contract/` files, and the cpu/memory pair. A build already carrying
+this release's hash gets the version tag assigned to it and no rebuild happens. Asking E2B which
+recipes it already holds is self-correcting where a `git diff` against the previous tag is not: after
+a release whose template build failed, the source is unchanged at the next attempt, so a diff would
+skip the rebuild and stamp a version onto a template that never got the change.
+
+`verify-agent-template` is the gate no docker build can stand in for. `template.ts`'s header names
+two mistakes — a missing `bash` (this SDK hardcodes `cmd: "/bin/bash"`) and a `runCmd` that needs
+`{ user: 'root' }` — that both produce a template which BUILDS CLEANLY and then fails on every run.
+It runs on the dedup path too: "the recipe did not change" says nothing about whether the published
+build still boots.
+
+To build it by hand (a dev template, or a first build in a fresh E2B project):
 
 ```bash
 cd sandbox-runner/agent-sandbox && pnpm install && E2B_API_KEY=<team key> pnpm exec tsx build.ts
 ```
 
-Until that runs after the rename, `Sandbox.create('tessary-agent-sandbox', …)` resolves
-nothing and both `/rca` and `/triage` fail on their first call.
+That no-argument form is unchanged and publishes under the `default` tag. `--release=`, `--verify=`,
+`--promote=` and `--rollback=` are the four verbs the workflow drives; every one of them is runnable
+on a laptop with the same key, which is the point of them living in `build.ts` rather than inline in
+a workflow step.
 
 ## Local agent backend (`task dev:local`)
 
 Both launcher paths — RCA (`/rca`) and Layer-2 triage (`/triage`) — drive the **`opencode`** CLI. By
 default the launcher runs each in a fresh **E2B microVM** (template
-`tessary-agent-sandbox`), which needs `E2B_API_KEY`, a built template, and Bedrock
-credentials. For local development you can instead run those scripts on the **host**,
+`tessary/tessary-agent-sandbox`, namespaced because E2B scopes template names to the project that
+built them), which needs `E2B_API_KEY` and Bedrock credentials. For local development you can instead run those scripts on the **host**,
 against a locally installed `opencode`, with no E2B at all:
 
 - **`SANDBOX_BACKEND`** — `docker` (default — see below) | `e2b` (opt-in) | `local`.

--- a/sandbox-runner/agent-sandbox/README.md
+++ b/sandbox-runner/agent-sandbox/README.md
@@ -23,19 +23,39 @@ The microVM every agentic lane runs in: it clones the target repo at HEAD and ru
   production traffic is true. It reads the substrate through MCP instead, and `checks/` under the
   work dir is the one path it may write — the agent computes what is mechanical rather than
   eyeballing it. (Node builtins only.)
-- `build.ts` — builds + publishes the template to the E2B cloud under alias **`tessary-agent-sandbox`** (what the launcher's `E2B_ANALYZER_TEMPLATE` expects).
+- `build.ts` — the ONLY thing in this repo that talks to E2B: builds, verifies and tags the
+  template. Published in our project as **`tessary-agent-sandbox`**, and **public**, so everyone
+  else reaches it as **`tessary/tessary-agent-sandbox`** — which is what the launcher's
+  `E2B_ANALYZER_TEMPLATE` default says.
 
 ## Build / publish
+
+Releases do this on their own. `.github/workflows/release.yml` drives the four verbs below from the
+`E2B_API_KEY` repository secret, and only rebuilds when the recipe actually changed — see
+[`sandbox-runner/README.md`](../README.md#deploy) for the job order and why it splits the way it
+does.
+
+By hand (a dev template, or the first build in a fresh E2B project):
+
 ```bash
 cd sandbox-runner/agent-sandbox
 pnpm install
 echo "E2B_API_KEY=<your team's key>" > .env     # or export it
 pnpm exec tsx build.ts                            # == pnpm run build
 ```
-- The `E2B_API_KEY` must be for the **same team** the launcher uses at runtime, or
-  `Sandbox.create('tessary-agent-sandbox', …)` won't find the template.
-- The alias is stable, so rebuilds update the same template.
-- Verify: `e2b template list` shows `tessary-agent-sandbox`.
+
+| verb | does | when |
+|---|---|---|
+| *(none)* | build + publish under the `default` tag | by hand |
+| `--release=<semver>` | build **only if the recipe hash changed**, tag `<semver>` + `recipe-<hash>` | `build-agent-template` |
+| `--verify=<semver>` | assert public + namespaced name, then boot it and run seven checks | `verify-agent-template` |
+| `--promote=<semver>` | move `latest` and `default` onto that build | `finalize` |
+| `--rollback=<semver>` | remove the `<semver>` tag, keep `recipe-<hash>` | `cleanup` |
+
+- The `E2B_API_KEY` must be for the **same team** that owns the template, or the build lands in a
+  different project under a name nothing references.
+- The name is stable, so rebuilds update the same template; tags are what distinguish builds.
+- Verify: `e2b template list` shows `tessary/tessary-agent-sandbox`.
 
 > Network egress: this template (unlike the air-gapped grader template) reaches
 > github.com + the model provider at run time. Credentials are never baked in —

--- a/sandbox-runner/agent-sandbox/build.ts
+++ b/sandbox-runner/agent-sandbox/build.ts
@@ -1,22 +1,45 @@
 // SPDX-License-Identifier: Apache-2.0
 import 'dotenv/config';
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { Template, defaultBuildLogger } from 'e2b';
+import { Sandbox, Template, defaultBuildLogger } from 'e2b';
 import { template } from './template';
 
 /**
- * Builds + publishes the observer-analysis template to the E2B cloud under the
- * alias the launcher expects (E2B_ANALYZER_TEMPLATE=tessary-agent-sandbox).
+ * Builds, verifies and tags the agent sandbox's E2B cloud template.
  *
- * Run from this directory:
- *   pnpm install
- *   E2B_API_KEY=<your team's key> pnpm exec tsx build.ts     (or put E2B_API_KEY in ./.env)
+ * THE ONE PLACE THAT TALKS TO E2B. Every call the release makes lives here rather than inlined in
+ * .github/workflows/release.yml, for the same reason scripts/publish-compose-artifact.sh owns
+ * every oras call: a workflow step cannot be run on a laptop, and this path's failures (a template
+ * that builds and then cannot exec, see template.ts's header) are exactly the ones you want to
+ * reproduce by hand.
  *
- * The alias is stable, so rebuilds update the same template; the launcher's
- * E2B_API_KEY must be for the SAME team this is built under.
+ *   tsx build.ts                     build + publish under the default tag (the human path)
+ *   tsx build.ts --release=<semver>  build IF THE RECIPE CHANGED, tag <semver> + recipe-<hash>
+ *   tsx build.ts --verify=<semver>   boot :<semver> and prove the runtime actually works
+ *   tsx build.ts --promote=<semver>  move `latest` and `default` onto :<semver>
+ *   tsx build.ts --rollback=<semver> remove the <semver> tag (the release's own rollback)
+ *
+ * Needs E2B_API_KEY for the team that owns the template, in the environment or ./.env.
+ *
+ * THE FOUR RELEASE VERBS MAP ONTO release.yml'S JOB ORDER, and the split is the same one that
+ * governs the docker images: --release and --verify are ADDITIVE (new tags nobody is using, which
+ * --rollback can simply delete), while --promote moves floating tags that the previous release is
+ * still serving from and deletion cannot undo. That is why --promote runs in finalize and nowhere
+ * earlier.
  */
-const ALIAS = 'tessary-agent-sandbox';
+
+/** The template's name inside our own E2B project. Build and tag operations use this. */
+const NAME = 'tessary-agent-sandbox';
+/**
+ * What everybody ELSE writes, and therefore what compose, server.js and --verify use. E2B
+ * namespaces a template by its project slug, so the bare NAME above resolves only for a key
+ * belonging to this project — a self-hoster who sets SANDBOX_BACKEND=e2b with their own key needs
+ * the namespaced form or `Sandbox.create` finds nothing. Held equal to docker-compose.yml's
+ * E2B_ANALYZER_TEMPLATE default by scripts/check-version-consistency.sh.
+ */
+const PUBLIC_REF = 'tessary/tessary-agent-sandbox';
 
 /**
  * Files template.ts bakes into /home/user/tessary-contract — the bundle contract the observer's
@@ -32,6 +55,23 @@ const CONTRACT_FILES = [
   'grader.schema.json',
 ];
 
+/** cpuCount/memoryMB are build INPUTS — a change to either produces a different sandbox. */
+const RESOURCES = { cpuCount: 2, memoryMB: 2048 };
+
+/**
+ * Everything that can change what the built template contains. Anything listed here is hashed into
+ * the recipe tag below; anything NOT listed is, by that omission, a claim that it cannot affect the
+ * image. Keep it exhaustive — a missed input means a changed template silently reuses an old build.
+ */
+const RECIPE_INPUTS = [
+  'template.ts',
+  'agent-stream.js',
+  'rca.js',
+  'triage.js',
+  'tessary-evals-validate',
+  ...CONTRACT_FILES.map((f) => `../../contract/${f}`),
+];
+
 function stageContract() {
   const src = path.resolve(__dirname, '../../contract');
   const vendor = path.resolve(__dirname, 'vendor');
@@ -42,14 +82,207 @@ function stageContract() {
   }
 }
 
-async function main() {
+/**
+ * A content address for the recipe, carried as a tag on the build it produced.
+ *
+ * THIS IS HOW "HAS IT CHANGED?" GETS ANSWERED WITHOUT ANY STATE IN THIS REPO. The alternative —
+ * `git diff <previous tag> -- sandbox-runner/agent-sandbox/` — is a statement about the SOURCE, and
+ * it is wrong in precisely the case that matters: a release whose template build failed leaves the
+ * source unchanged at the next attempt, so a diff-based check would skip the rebuild and tag a
+ * version onto a template that never got the change. Asking the registry which recipes it already
+ * holds is self-correcting, because the thing being asked is the thing being published.
+ *
+ * The path is hashed alongside the bytes so that moving a file is a change, and the inputs are
+ * sorted so the digest cannot depend on the order of the list above.
+ */
+function recipeHash(): string {
+  const h = crypto.createHash('sha256');
+  h.update(JSON.stringify(RESOURCES));
+  for (const rel of [...RECIPE_INPUTS].sort()) {
+    h.update('\0');
+    h.update(rel);
+    h.update('\0');
+    h.update(fs.readFileSync(path.resolve(__dirname, rel)));
+  }
+  return `recipe-${h.digest('hex').slice(0, 12)}`;
+}
+
+/** GitHub Actions reads job outputs off stdout as `key=value`; a local run just sees them. */
+function emit(key: string, value: string) {
+  console.log(`${key}=${value}`);
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `${key}=${value}\n`);
+  }
+}
+
+/**
+ * The one thing the SDK has no helper for. `public` decides whether a key from ANOTHER E2B project
+ * can resolve PUBLIC_REF at all, and it is a console toggle a human can flip back without touching
+ * this repo — so the release ASSERTS it rather than setting it. Asserting is deliberate: a
+ * workflow that quietly re-publishes a template somebody deliberately made private is a worse
+ * failure than a red release telling them which it is.
+ */
+async function templateInfo(): Promise<{ templateID: string; public: boolean; names: string[] }> {
+  const key = process.env.E2B_API_KEY;
+  if (!key) throw new Error('E2B_API_KEY is not set');
+  const domain = process.env.E2B_DOMAIN || 'e2b.dev';
+  const res = await fetch(`https://api.${domain}/v2/templates`, { headers: { 'X-API-KEY': key } });
+  if (!res.ok) throw new Error(`GET /v2/templates -> ${res.status} ${await res.text()}`);
+  const list = (await res.json()) as Array<{ templateID: string; public: boolean; names: string[] }>;
+  const found = list.find((t) => (t.names || []).some((n) => n === PUBLIC_REF || n === NAME));
+  if (!found) {
+    throw new Error(
+      `no template named ${PUBLIC_REF} in this project. Either E2B_API_KEY belongs to a different `
+        + `team, or the template was never built — run \`pnpm exec tsx build.ts\` with the team's key.`,
+    );
+  }
+  return found;
+}
+
+/** Build and publish under the default tag: the documented by-hand path, unchanged. */
+async function buildDefault() {
   stageContract();
-  const info = await Template.build(template, ALIAS, {
-    cpuCount: 2,
-    memoryMB: 2048,
+  const info = await Template.build(template, NAME, { ...RESOURCES, onBuildLogs: defaultBuildLogger() });
+  console.log(`built template '${info.name}' (id=${info.templateId}) tags=${info.tags?.join(',')}`);
+}
+
+/**
+ * ADDITIVE ONLY. Writes `<version>` and `recipe-<hash>`, both new, both removable by --rollback.
+ * Writes NEITHER `latest` NOR `default` — those are --promote's, because they already point at the
+ * previous release and deleting them is an outage rather than a rollback.
+ */
+async function release(version: string) {
+  const recipe = recipeHash();
+  emit('recipe', recipe);
+
+  const existing = await Template.getTags(NAME).catch(() => []);
+  const match = existing.find((t) => t.tag === recipe);
+  if (match) {
+    // The recipe is already published, so there is nothing to build — just give this release's
+    // number to the build that already carries it. A rebuild here would be identical by
+    // construction and cost ~10 minutes to prove it.
+    await Template.assignTags(`${NAME}:${recipe}`, [version]);
+    console.log(`recipe unchanged (${recipe}); tagged existing build ${match.buildId} as ${version}`);
+    emit('rebuilt', 'false');
+    emit('build_id', match.buildId);
+    return;
+  }
+
+  stageContract();
+  const info = await Template.build(template, NAME, {
+    ...RESOURCES,
+    tags: [version, recipe],
     onBuildLogs: defaultBuildLogger(),
   });
-  console.log(`built template '${info.name}' (id=${info.templateId}) tags=${info.tags?.join(',')}`);
+  console.log(`built ${info.name} id=${info.templateId} build=${info.buildId} tags=${info.tags?.join(',')}`);
+  emit('rebuilt', 'true');
+  emit('build_id', info.buildId);
+}
+
+/**
+ * THE STEP THAT CAN ACTUALLY GO RED, and the reason it exists is written in template.ts's own
+ * header: this SDK hardcodes `cmd: "/bin/bash"`, E2B's runCmd is not root where Docker's RUN is,
+ * and BOTH of those produce a template that BUILDS CLEANLY and then fails on every single run. No
+ * image build can surface either. So the release boots the thing and runs commands through it.
+ *
+ * It runs on the dedup path too. "We did not rebuild" is a statement about the recipe, not about
+ * whether the published build still resolves and boots.
+ */
+async function verify(version: string) {
+  const info = await templateInfo();
+  if (!info.public) {
+    throw new Error(
+      `${PUBLIC_REF} is not public. A self-hoster's own E2B key cannot resolve it, so the template `
+        + `reference this release stamps into the compose artifact would be dead for everyone `
+        + `outside this team. Re-publish it in the E2B console's Templates tab (or `
+        + `\`e2b template publish ${NAME}\`) and re-run.`,
+    );
+  }
+  if (!info.names.includes(PUBLIC_REF)) {
+    throw new Error(
+      `this project publishes the template as ${info.names.join(', ')}, but this repo references `
+        + `${PUBLIC_REF}. The project slug changed; update PUBLIC_REF here and the `
+        + `E2B_ANALYZER_TEMPLATE defaults check-version-consistency.sh holds equal to it.`,
+    );
+  }
+
+  const ref = `${PUBLIC_REF}:${version}`;
+  console.log(`booting ${ref} (templateID=${info.templateID}, public=${info.public})`);
+  const sbx = await Sandbox.create(ref, { timeoutMs: 180_000 });
+  try {
+    // Each of these is a distinct failure this release must not ship, not a smoke test for its own
+    // sake: bash missing (the SDK cannot exec at all), the opencode prune having deleted the
+    // variant on PATH, PyYAML absent (the validator crashes in-VM), a script or contract file that
+    // never got copied, and the native re2 addon failing to load.
+    const checks: Array<[string, string]> = [
+      ['bash is the exec shell', 'echo "$BASH_VERSION" | grep -q .'],
+      ['opencode runs', 'opencode --version'],
+      ['pyyaml is baked', 'python3 -c "import yaml"'],
+      ['validator is on PATH', 'command -v tessary-evals-validate'],
+      ['contract is baked', 'test -f /home/user/tessary-contract/validate.py'],
+      ['agent scripts are baked', 'test -f /home/user/rca.js && test -f /home/user/triage.js && test -f /home/user/agent-stream.js'],
+      ['native modules load', 'cd /home/user && node -e "require(\'re2\'); require(\'acorn\')"'],
+    ];
+    const failed: string[] = [];
+    for (const [label, cmd] of checks) {
+      const r = await sbx.commands.run(cmd, { timeoutMs: 60_000 }).catch((e: unknown) => ({
+        exitCode: 1,
+        stderr: e instanceof Error ? e.message : String(e),
+        stdout: '',
+      }));
+      if (r.exitCode === 0) {
+        console.log(`  ok    ${label}`);
+      } else {
+        console.error(`  FAIL  ${label}: ${(r.stderr || r.stdout || '').trim().slice(0, 400)}`);
+        failed.push(label);
+      }
+    }
+    if (failed.length) throw new Error(`${ref} booted but ${failed.length} check(s) failed: ${failed.join(', ')}`);
+    console.log(`OK: ${ref} resolves, boots and passes ${checks.length} checks`);
+  } finally {
+    await sbx.kill().catch(() => {});
+  }
+}
+
+/**
+ * THE COMMIT POINT'S SHARE OF THE WORK. `latest` is what compose's floating default resolves to;
+ * `default` is what a BARE `tessary-agent-sandbox` reference means to E2B, which is what every
+ * config written before this change says. Both move together so the two spellings can never
+ * disagree about which build is current.
+ */
+async function promote(version: string) {
+  const res = await Template.assignTags(`${NAME}:${version}`, ['latest', 'default']);
+  console.log(`promoted ${NAME}:${version} -> latest, default (build ${res.buildId})`);
+}
+
+/**
+ * The failure path only. Takes away the version tag this run added, and DELIBERATELY LEAVES
+ * `recipe-<hash>`: it names a build by its contents, so it cannot come to mean the wrong thing, and
+ * leaving it is what lets the retry skip a rebuild it already paid for.
+ */
+async function rollback(version: string) {
+  await Template.removeTags(NAME, [version]);
+  console.log(`removed tag ${version} from ${NAME}`);
+}
+
+function argOf(flag: string): string | undefined {
+  const hit = process.argv.slice(2).find((a) => a.startsWith(`--${flag}=`));
+  return hit?.slice(flag.length + 3);
+}
+
+async function main() {
+  const verbs = ['release', 'verify', 'promote', 'rollback'] as const;
+  const verb = verbs.find((v) => argOf(v) !== undefined);
+  if (!verb) return buildDefault();
+
+  const version = argOf(verb)!;
+  if (!/^[0-9]+\.[0-9]+\.[0-9]+$/.test(version)) {
+    throw new Error(`--${verb} takes a semantic version, got '${version}'`);
+  }
+  if (verb === 'release') return release(version);
+  if (verb === 'verify') return verify(version);
+  if (verb === 'promote') return promote(version);
+  return rollback(version);
 }
 
 main().catch((err) => {

--- a/sandbox-runner/launcher/server.js
+++ b/sandbox-runner/launcher/server.js
@@ -56,11 +56,18 @@
  *                         All three backends get the SAME provider config and the SAME model
  *                         (see agentEnvs / toProviderModel), so they cannot drift apart.
  *   E2B_API_KEY           E2B cloud key (stays here, never sent to the backend) — E2B backend only
- *   E2B_ANALYZER_TEMPLATE agent sandbox template name/id (default tessary-agent-sandbox). Renamed
- *                         from evals-observer-analyzer with the service: the published cloud
- *                         template must be rebuilt under the new alias before an e2b-backed deploy,
- *                         or Sandbox.create resolves nothing and both /rca and /triage fail on
- *                         their first call — see agent-sandbox/build.ts.
+ *   E2B_ANALYZER_TEMPLATE agent sandbox template name/id (default
+ *                         tessary/tessary-agent-sandbox:latest). NAMESPACED because E2B scopes a
+ *                         template name to the project that built it: a bare
+ *                         `tessary-agent-sandbox` resolves only for a key belonging to the Tessary
+ *                         team, which made SANDBOX_BACKEND=e2b unusable for a self-hoster with
+ *                         their own key. The template is published public, so `tessary/…` is
+ *                         reachable by anyone's key. VERSIONED because it is the second recipe for
+ *                         the same runtime AGENT_IMAGE names — .github/workflows/release.yml
+ *                         publishes both from one dispatch and repoints both floating tags in
+ *                         finalize, so an install can never run a backend from one release against
+ *                         an agent from another. Rebuilding it is no longer a human step; see
+ *                         agent-sandbox/build.ts.
  *   SANDBOX_TIMEOUT_MS    per-sandbox wall clock (default 60000)
  *   DOCKER_SOCKET_PATH    unix socket the docker backend talks the Engine API over
  *                         (default /var/run/docker.sock — the socket docker-compose.yml mounts
@@ -157,7 +164,12 @@ const E2B_API_KEY = process.env.E2B_API_KEY;
 // E2B_TEMPLATE / 'evals-grader-runner' was the second alias here — the grader sandbox /grade and
 // /lint ran in. Both routes were removed, so the constant, the env var and its compose entries
 // are gone. The published cloud template is orphaned in E2B; nothing in this tree can delete it.
-const ANALYZER_TEMPLATE = process.env.E2B_ANALYZER_TEMPLATE || 'tessary-agent-sandbox';
+// Namespaced by the E2B project slug and pinned to the floating `latest` tag release.yml's
+// finalize repoints. A BARE name resolves only for a key belonging to the project that built the
+// template (and, to E2B, means `:default`), so the previous bare default was unreachable for any
+// self-hoster using their own E2B key. Held equal to docker-compose.yml's default by
+// scripts/check-version-consistency.sh.
+const ANALYZER_TEMPLATE = process.env.E2B_ANALYZER_TEMPLATE || 'tessary/tessary-agent-sandbox:latest';
 const SANDBOX_TIMEOUT_MS = Number(process.env.SANDBOX_TIMEOUT_MS || 60000);
 const MAX_BODY_BYTES = 8 * 1024 * 1024;
 // Cap on accumulated child stdout in the local and docker backends (neither honors a

--- a/scripts/check-compose-artifact.sh
+++ b/scripts/check-compose-artifact.sh
@@ -225,6 +225,12 @@ missing = [
     service for service in ("backend", "frontend", "sandbox-runner", "agent-sandbox")
     if f"tessaryai/tessary:{service}-{probe}" not in pinned
 ]
+# The E2B agent template is the fifth pinned reference and the only one that is not a docker ref,
+# so the loop above cannot see it. It is the same runtime as agent-sandbox, reached by the other
+# SANDBOX_BACKEND — leaving it floating would let a pinned artifact resolve an agent from a
+# different release than the backend it ships with.
+if f"tessary/tessary-agent-sandbox:{probe}" not in pinned:
+    missing.append("the E2B template (E2B_ANALYZER_TEMPLATE)")
 if missing:
     print(
         f"FAIL: the release stamp left {', '.join(missing)} floating. Every published image "
@@ -234,7 +240,13 @@ if missing:
     )
     sys.exit(1)
 
-if pinned.replace(f"-{probe}", "-latest") != unpinned:
+def unpin(text):
+    # Two separators, because the artifact pins two kinds of reference: docker's `name-<version>`
+    # and E2B's `name:<version>`.
+    return text.replace(f"-{probe}", "-latest").replace(f":{probe}", ":latest")
+
+
+if unpin(pinned) != unpinned:
     print(
         "FAIL: the release stamp changed more than the image versions. Rendered configs differ "
         "once the probe version is mapped back to `latest`.",
@@ -242,12 +254,12 @@ if pinned.replace(f"-{probe}", "-latest") != unpinned:
     )
     import difflib
     for line in list(difflib.unified_diff(
-        unpinned.splitlines(), pinned.replace(f"-{probe}", "-latest").splitlines(),
+        unpinned.splitlines(), unpin(pinned).splitlines(),
         "unpinned", "pinned-mapped-back", lineterm="",
     ))[:40]:
         print("  " + line, file=sys.stderr)
     sys.exit(1)
-print("check-compose-artifact: ok   the stamp pins all four images and changes nothing else")
+print("check-compose-artifact: ok   the stamp pins all four images + the E2B template, and changes nothing else")
 PY
 fi
 

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -61,16 +61,31 @@ p = sys.argv[1]
 t = open(p, encoding="utf-8").read()
 open(p, "w", encoding="utf-8").write(t.replace("backend-${TESSARY_VERSION:-latest}", "backend-${TESSARY_VERSION:-0.1.0}", 1))
 PY
-    echo "VERSION_SOURCE_SELFTEST=1: checking a scratch tree with a reintroduced literal and a de-floated default." >&2
+    # Breakage 3: the E2B template pinned to a version. Its own pattern, because it is the one
+    # published reference that is not a `tessaryai/tessary:` docker ref — neither regex above would
+    # ever see it, so this arm is what keeps that third pattern from being decorative.
+    printf '\n# E2B_ANALYZER_TEMPLATE=tessary/tessary-agent-sandbox:0.1.0\n' >> "$T/.env.example"
+    echo "VERSION_SOURCE_SELFTEST=1: checking a scratch tree with two reintroduced literals and a de-floated default." >&2
     set +e
-    (cd "$T" && VERSION_SOURCE_SELFTEST=0 bash scripts/check-version-consistency.sh)
+    (cd "$T" && VERSION_SOURCE_SELFTEST=0 bash scripts/check-version-consistency.sh) 2>"$T/out.txt"
     status=$?
     set -e
+    cat "$T/out.txt" >&2
     if [ "$status" -eq 0 ]; then
         echo "SELFTEST FAILED: a reintroduced version literal was expected to fail this script, and it did not." >&2
         exit 1
     fi
-    echo "SELFTEST OK: the reintroduced literal and the de-floated default both failed this script (see FAIL lines above)." >&2
+    # Each breakage named individually: a single red proves only that SOMETHING fired, and the
+    # E2B pattern is new enough that "the script went red" is not evidence it works.
+    for needle in "tessaryai/tessary:agent-sandbox-0.1.0" \
+                  "tessary/tessary-agent-sandbox:0.1.0" \
+                  "backend image default"; do
+        if ! grep -qF "$needle" "$T/out.txt"; then
+            echo "SELFTEST FAILED: nothing in the output named '$needle', so that breakage went undetected." >&2
+            exit 1
+        fi
+    done
+    echo "SELFTEST OK: both reintroduced literals and the de-floated default were each named in the failure output." >&2
     exit 0
 fi
 
@@ -89,6 +104,10 @@ fail = False
 # compose form `${TESSARY_VERSION:-0.1.0}` however it is spelled.
 LITERAL = re.compile(r"tessaryai/tessary:[A-Za-z][A-Za-z-]*-[0-9]+\.[0-9]+\.[0-9]+")
 NESTED = re.compile(r"TESSARY_VERSION:-[0-9]+\.[0-9]+\.[0-9]+")
+# The E2B agent template is the one published artifact that is not a docker ref, so neither
+# pattern above would ever see a pin of it. Same rule, same reason: `tessary/…:0.4.2` written
+# down anywhere is a second copy of the version, and the copy is what goes stale.
+E2B_LITERAL = re.compile(r"tessary/tessary-agent-sandbox:[0-9]+\.[0-9]+\.[0-9]+")
 
 # Named, reasoned exemptions: a file whose version literals RECORD something that was true at a
 # date rather than instructing a machine or a reader to pull it.
@@ -125,7 +144,7 @@ for path in tracked:
     except (OSError, UnicodeDecodeError):
         continue  # binary or unreadable: carries no version literal to find
     scanned += 1
-    for found in set(LITERAL.findall(text)) | set(NESTED.findall(text)):
+    for found in set(LITERAL.findall(text)) | set(NESTED.findall(text)) | set(E2B_LITERAL.findall(text)):
         print(
             f"FAIL: {path} hard-codes a published version: \"{found}\". No file in this tree may "
             "hold a copy of the version — the git tag release.yml pushes is the only source of "
@@ -150,6 +169,17 @@ SITES = [
      "AGENT_IMAGE: ${AGENT_IMAGE:-tessaryai/tessary:agent-sandbox-${TESSARY_VERSION:-latest}}", 1),
     ("sandbox-runner/launcher/server.js", "AGENT_IMAGE code default",
      "process.env.AGENT_IMAGE || 'tessaryai/tessary:agent-sandbox-latest'", 1),
+    # The E2B template — the SECOND recipe for the one agent runtime, and the reference
+    # SANDBOX_BACKEND=e2b follows where the three above are what the docker backend follows. It is
+    # namespaced by the E2B project slug because a bare name resolves only for a key belonging to
+    # the project that built the template, which made it unreachable for a self-hoster's own key.
+    # sandbox-runner/agent-sandbox/build.ts's PUBLIC_REF is the other half of this pair.
+    ("docker-compose.yml", "E2B template default",
+     "E2B_ANALYZER_TEMPLATE: ${E2B_ANALYZER_TEMPLATE:-tessary/tessary-agent-sandbox:${TESSARY_VERSION:-latest}}", 1),
+    ("docker-compose.dev.yml", "E2B template default",
+     "E2B_ANALYZER_TEMPLATE: ${E2B_ANALYZER_TEMPLATE:-tessary/tessary-agent-sandbox:${TESSARY_VERSION:-latest}}", 1),
+    ("sandbox-runner/launcher/server.js", "E2B template code default",
+     "process.env.E2B_ANALYZER_TEMPLATE || 'tessary/tessary-agent-sandbox:latest'", 1),
 ]
 
 for path, label, needle, count in SITES:

--- a/scripts/lib/pin-compose-version.py
+++ b/scripts/lib/pin-compose-version.py
@@ -29,10 +29,12 @@ import re
 import sys
 
 FLOATING = "${TESSARY_VERSION:-latest}"
-# Three `image:` keys (backend, frontend, sandbox-runner) plus sandbox-runner's AGENT_IMAGE env
-# value, which is an env value rather than a compose `image:` key but is still a pull instruction
-# the artifact hands a remote install (D10's own reasoning).
-EXPECTED_SITES = 4
+# Three `image:` keys (backend, frontend, sandbox-runner) plus TWO env values on sandbox-runner —
+# AGENT_IMAGE and E2B_ANALYZER_TEMPLATE. Neither is a compose `image:` key, but both are still a
+# pull instruction the artifact hands a remote install (D10's own reasoning), and they are the two
+# recipes for the one agent runtime: whichever SANDBOX_BACKEND an install picks, the reference it
+# follows has to name this release.
+EXPECTED_SITES = 5
 SEMVER = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.\-]+)?$")
 
 


### PR DESCRIPTION
The agent runtime has **two recipes, not one**: `sandbox-runner/agent-sandbox/Dockerfile` (what `SANDBOX_BACKEND=docker` runs) and its `template.ts` (an E2B cloud template, what `SANDBOX_BACKEND=e2b` runs). They are alternatives an install chooses between, never a pair that reference each other — so publishing one without the other leaves half the backends on a stale agent.

`release.yml` published the first four artifacts and not the fifth. The E2B half was a human step: somebody with the team's key ran `tsx build.ts`, and the published template was whatever that last run left behind, tied to no version at all.

## What the release does now

| job | writes | undone by |
|---|---|---|
| `build-agent-template` | `<version>` and `recipe-<hash>` — **only builds if the recipe changed** | `cleanup` |
| `verify-agent-template` | nothing; boots `tessary/tessary-agent-sandbox:<version>` and runs seven checks | n/a |
| `finalize` | moves `latest` and `default` onto that build | nothing — this is the commit point |

The split follows the one the workflow already had. `<version>` and `recipe-<hash>` are new tags nobody is using, so they are written early and deleted on failure. `latest` and `default` are not new — E2B resolves a bare `tessary-agent-sandbox` to `:default`, so both already point at the previous release and moving them is not reversible by deleting anything.

## "If it has changed" is answered by E2B, not by git

`build.ts` hashes the real build inputs — `template.ts`, the three agent scripts, the validator wrapper, the five `contract/` files, the cpu/memory pair — and carries the digest as a tag. A build already wearing this release's hash gets the version assigned to it and no rebuild happens.

A `git diff` against the base tag answers the same question about the *source*, and is wrong in the one case that matters: after a release whose template build failed, the source is unchanged at the next attempt, so a diff would skip the rebuild and stamp a version onto a template that never got the change.

## Why the boot check exists

`template.ts`'s own header names two mistakes — a missing `bash` (the SDK hardcodes `cmd: "/bin/bash"`, and Alpine ships busybox `ash`) and a `runCmd` needing `{ user: 'root' }` — that both produce a template which **builds cleanly and then fails on every run**. No docker build can surface either.

It runs on the dedup path too: "the recipe did not change" says nothing about whether the published build still resolves and boots.

Measured against the live template, the E2B portion is **22s** — create 1.2s, `opencode --version` 11.1s, native modules 4.2s, pyyaml 2.6s, the rest under a second each. It runs in parallel with four multi-arch image builds, so it is not on the critical path unless the template actually rebuilds.

## Consumption, which was separately broken

E2B scopes a template name to the project that built it. The bare `tessary-agent-sandbox` every config said resolved **only for a key belonging to this team** — a self-hoster who set `SANDBOX_BACKEND=e2b` with their own key got `Sandbox.create` finding nothing. That is a pre-existing bug, not one this PR introduces.

The template is now published public, so:

- `E2B_ANALYZER_TEMPLATE` reads `${E2B_ANALYZER_TEMPLATE:-tessary/tessary-agent-sandbox:${TESSARY_VERSION:-latest}}` in both compose files
- `server.js`'s fallback is namespaced to match
- `pin-compose-version.py`'s `EXPECTED_SITES` goes 4 → 5
- both compose render checks in `release.yml` assert the E2B pin
- `check-version-consistency.sh` gains the three new floating defaults plus an `E2B_LITERAL` pattern — the E2B template is the one published reference that is not a `tessaryai/tessary:` docker ref, so neither existing regex would ever have seen a pin of it

That script's self-test now names each breakage individually rather than asserting a single red, since "the script went red" was not evidence the new pattern worked.

## Reviewer notes

**`E2B_API_KEY` is the only optional secret.** A fork without one still publishes the four images; both template jobs no-op with a warning. The gate sits inside each step rather than a job-level `if:` because `secrets` is unavailable in a job `if`, and a *skipped* job skips everything that `needs:` it — which would silently take `publish-compose` and `finalize` down with it.

**The version correspondence is many-to-one.** `agent-sandbox-0.4.0` and `-0.5.0` are always distinct docker manifests (`IMAGE_VERSION` is baked in), while `tessary/tessary-agent-sandbox:0.4.0` and `:0.5.0` may share a `buildId` when nothing in the template changed. Every released version has a tag that resolves; two of them may name one build.

**E2B publishes no build-retention policy.** Tags can be removed without deleting the build, and a build stays addressable by `<template>:<buildId>` regardless of tags, but nothing promises old builds are never swept. `build-agent-template` prints its `buildId` to the step summary so a rollback can pin one directly if that ever bites.

**Not exercised end to end.** `--release`, `--verify` and `--promote` against real E2B — a template build is ~10 minutes and `--verify` boots a billed sandbox, so the first dispatch is where those run for real. Read-only SDK calls (`Template.getTags`, `Template.exists`) were confirmed against the live template, and the seven checks were timed against the currently published build (all pass). Expect a full build on the first dispatch: no `recipe-*` tag exists yet, so it cannot dedup.

## Verification

`check-version-consistency` (plus its self-test), `check-compose-artifact`, `check-docs-links`, `check-required-inputs`, `check-sandbox-runner-launcher` all pass. `tsc --noEmit --strict` clean on `build.ts`. Every `run:` block bash-syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
