### PR TITLE
feat(mcp): return span measurements from get_finding_evidence

### DIFF
--- a/backend/analysis/src/main/java/ai/tessary/classifier/finding/BehaviorDtos.java
+++ b/backend/analysis/src/main/java/ai/tessary/classifier/finding/BehaviorDtos.java
@@ -100,7 +100,8 @@ public final class BehaviorDtos {
             Map<String, Long> recordedCounts) {}
 
     /**
-     * One row of the finding page's evidence table: the ref, and the span it names.
+     * One row of a finding's evidence, joined: the ref, and the span it names. Rendered by the finding
+     * page's evidence table, and returned on the MCP door minus the two previews.
      *
      * <p>The unit here is whatever the detector measured; for tool error and both drift measures
      * that is a span, one ref per call. Rendering these as traces would print the same trace four

--- a/backend/analysis/src/main/java/ai/tessary/classifier/finding/FindingEvidenceRepository.java
+++ b/backend/analysis/src/main/java/ai/tessary/classifier/finding/FindingEvidenceRepository.java
@@ -332,8 +332,9 @@ public class FindingEvidenceRepository {
     /**
      * {@link #page}, with the span each ref names joined on. Same keyset, order and over-fetch, so a
      * reader paging this and a reader paging the refs see the population in the same sequence; kept
-     * separate from {@link #page} because the MCP door returns ids and no bodies, while a person looking
-     * at a table needs the row to say something.
+     * separate from {@link #page} because the dossier's enumeration wants ids and nothing else, while a
+     * reader judging one row — a person at the table, an agent on the MCP door — needs the row to say
+     * something.
      *
      * <p>The join is LEFT and falls back to the trace's logical root for a trace-grain ref, so a
      * behaviour-drift finding still renders a name and a time rather than an id and four dashes. A ref
@@ -341,7 +342,8 @@ public class FindingEvidenceRepository {
      *
      * <p>Payloads are normally kept off list and sweep surfaces; this join is the bounded exception, a
      * keyset page of at most {@code limit} spans, 1:1 on the span primary key, with columns truncated in
-     * SQL so a page costs {@code limit × 2 × PREVIEW_CHARS} however large the payloads behind it are.
+     * SQL so a page costs {@code limit × 2 × PREVIEW_CHARS} however large the payloads behind it are. The
+     * previews are for the table; the MCP door drops them and sends callers to {@code get_span}.
      */
     public SpanPage spanPage(
             String projectId, String findingId, @Nullable String role, int limit, @Nullable String cursor) {

--- a/backend/analysis/src/main/resources/prompt-craft/rca/mcp_door.md
+++ b/backend/analysis/src/main/resources/prompt-craft/rca/mcp_door.md
@@ -7,12 +7,15 @@ finding is about. The dossier states the claim; you go and read it.
   cheap first call, always. `counts` is what SURVIVES and can still be opened;
   `recordedCounts` is what the detector wrote at finding-open, so counts below recorded means
   substrate aged out, never a lost write.
-- `get_finding_evidence(finding_id, role=…, limit=…, cursor=…)` — the refs themselves
-  (`role`, `grain`, `sessionId`, `traceId`, `spanId`, `rank`) in the detector's own stable
-  order. Field names are camelCase on this surface, and the next page's token is
-  `nextCursor`. Role `baseline` is the BEFORE side; every other role is what was flagged.
-  There is NO sampling mode: take the stride or the draw you want, and say which one you
-  took.
+- `get_finding_evidence(finding_id, role=…, limit=…, cursor=…)` — the rows themselves, under
+  `rows`, in the detector's own stable order. Each row carries what was MEASURED on it, not
+  just a pointer to it: `role`, `rank`, `sessionId`, `traceId`, `spanId`, `name`, `kind`,
+  `status`, `level`, `errorType`, `startedAt`, `latencyMs`, `totalTokens`, `totalCost`,
+  `model`, `callSiteId`. Compare the two sides on the page itself, and pick the rows you open
+  from the numbers. The payloads are NOT on this page; `get_span` is where a body comes from.
+  Field names are camelCase on this surface, and the next page's token is `nextCursor`. Role
+  `baseline` is the BEFORE side; every other role is what was flagged. No sampling. Page the
+  whole role and compute over all of it.
 - `get_trace(trace_id)` and `get_span(trace_id, span_id)` — the bodies behind a ref. A span
   id is unique only within its trace, which is why get_span takes both.
 - `list_traces` / `list_spans` / `list_sessions` / `get_session` — this project's traffic

--- a/backend/analysis/src/main/resources/prompt-craft/triage/mcp_door.md
+++ b/backend/analysis/src/main/resources/prompt-craft/triage/mcp_door.md
@@ -9,11 +9,14 @@ finding is about. The dossier states the claim; you go and check it.
   substrate aged out, never a lost write. ZERO in BOTH under `baseline` is a real state, not
   missing evidence: several detectors compare against a fitted model and have no reference
   rows to enumerate. Read it as "no enumerable reference side" and say so in your ruling.
-- `get_finding_evidence(finding_id, role=…, limit=…, cursor=…)` — the refs themselves
-  (`role`, `grain`, `sessionId`, `traceId`, `spanId`, `rank`) in the detector's own stable
-  order. Field names are camelCase on this surface, and the next page's token is
-  `nextCursor`. There is NO sampling mode: take the stride or the draw you want, and say in
-  your citation which one you took.
+- `get_finding_evidence(finding_id, role=…, limit=…, cursor=…)` — the rows themselves, under
+  `rows`, in the detector's own stable order. Each row carries what was MEASURED on it, not
+  just a pointer to it: `role`, `rank`, `sessionId`, `traceId`, `spanId`, `name`, `kind`,
+  `status`, `level`, `errorType`, `startedAt`, `latencyMs`, `totalTokens`, `totalCost`,
+  `model`, `callSiteId`. Rank and compare on the page itself, and pick the rows you open from
+  the numbers. The payloads are NOT on this page; `get_span` is where a body comes from.
+  Field names are camelCase on this surface, and the next page's token is `nextCursor`. No
+  sampling. Page the whole role and compute over all of it.
 - `get_trace(trace_id)` and `get_span(trace_id, span_id)` — the bodies behind a ref. A span id
   is unique only within its trace, which is why get_span takes both.
 - `list_traces` / `list_spans` / `list_sessions` / `get_session` — this project's traffic when

--- a/backend/analysis/src/main/resources/prompt-craft/triage/rules.md
+++ b/backend/analysis/src/main/resources/prompt-craft/triage/rules.md
@@ -15,8 +15,8 @@
    said — read them and see, rather than accepting that they must.
 5. **Always open the evidence, and write the code to check it.** Never rule from the summary.
    Anything mechanical — a count, a rate, a quantile, a share, a date range — gets COMPUTED
-   by a script you wrote and ran, never eyeballed. State the sample you took: which refs, how
-   many, in what order.
+   by a script you wrote and ran, never eyeballed. Compute over all the rows, not a sample.
+   Say which ones you opened.
 6. **Unsure means close.** `unclear` closes the finding, and that is the intended outcome
    whenever the evidence does not settle it. A cause that is real keeps firing and comes back
    for a second look; one that never fires again cost nobody a decision.

--- a/backend/analysis/src/test/resources/prompt-golden/AgenticRcaEngine.MCP_DOOR.txt
+++ b/backend/analysis/src/test/resources/prompt-golden/AgenticRcaEngine.MCP_DOOR.txt
@@ -7,12 +7,15 @@ finding is about. The dossier states the claim; you go and read it.
   cheap first call, always. `counts` is what SURVIVES and can still be opened;
   `recordedCounts` is what the detector wrote at finding-open, so counts below recorded means
   substrate aged out, never a lost write.
-- `get_finding_evidence(finding_id, role=…, limit=…, cursor=…)` — the refs themselves
-  (`role`, `grain`, `sessionId`, `traceId`, `spanId`, `rank`) in the detector's own stable
-  order. Field names are camelCase on this surface, and the next page's token is
-  `nextCursor`. Role `baseline` is the BEFORE side; every other role is what was flagged.
-  There is NO sampling mode: take the stride or the draw you want, and say which one you
-  took.
+- `get_finding_evidence(finding_id, role=…, limit=…, cursor=…)` — the rows themselves, under
+  `rows`, in the detector's own stable order. Each row carries what was MEASURED on it, not
+  just a pointer to it: `role`, `rank`, `sessionId`, `traceId`, `spanId`, `name`, `kind`,
+  `status`, `level`, `errorType`, `startedAt`, `latencyMs`, `totalTokens`, `totalCost`,
+  `model`, `callSiteId`. Compare the two sides on the page itself, and pick the rows you open
+  from the numbers. The payloads are NOT on this page; `get_span` is where a body comes from.
+  Field names are camelCase on this surface, and the next page's token is `nextCursor`. Role
+  `baseline` is the BEFORE side; every other role is what was flagged. No sampling. Page the
+  whole role and compute over all of it.
 - `get_trace(trace_id)` and `get_span(trace_id, span_id)` — the bodies behind a ref. A span
   id is unique only within its trace, which is why get_span takes both.
 - `list_traces` / `list_spans` / `list_sessions` / `get_session` — this project's traffic

--- a/backend/analysis/src/test/resources/prompt-golden/BehaviorTriageEngine.MCP_DOOR.txt
+++ b/backend/analysis/src/test/resources/prompt-golden/BehaviorTriageEngine.MCP_DOOR.txt
@@ -9,11 +9,14 @@ finding is about. The dossier states the claim; you go and check it.
   substrate aged out, never a lost write. ZERO in BOTH under `baseline` is a real state, not
   missing evidence: several detectors compare against a fitted model and have no reference
   rows to enumerate. Read it as "no enumerable reference side" and say so in your ruling.
-- `get_finding_evidence(finding_id, role=…, limit=…, cursor=…)` — the refs themselves
-  (`role`, `grain`, `sessionId`, `traceId`, `spanId`, `rank`) in the detector's own stable
-  order. Field names are camelCase on this surface, and the next page's token is
-  `nextCursor`. There is NO sampling mode: take the stride or the draw you want, and say in
-  your citation which one you took.
+- `get_finding_evidence(finding_id, role=…, limit=…, cursor=…)` — the rows themselves, under
+  `rows`, in the detector's own stable order. Each row carries what was MEASURED on it, not
+  just a pointer to it: `role`, `rank`, `sessionId`, `traceId`, `spanId`, `name`, `kind`,
+  `status`, `level`, `errorType`, `startedAt`, `latencyMs`, `totalTokens`, `totalCost`,
+  `model`, `callSiteId`. Rank and compare on the page itself, and pick the rows you open from
+  the numbers. The payloads are NOT on this page; `get_span` is where a body comes from.
+  Field names are camelCase on this surface, and the next page's token is `nextCursor`. No
+  sampling. Page the whole role and compute over all of it.
 - `get_trace(trace_id)` and `get_span(trace_id, span_id)` — the bodies behind a ref. A span id
   is unique only within its trace, which is why get_span takes both.
 - `list_traces` / `list_spans` / `list_sessions` / `get_session` — this project's traffic when

--- a/backend/analysis/src/test/resources/prompt-golden/BehaviorTriageEngine.RULES.txt
+++ b/backend/analysis/src/test/resources/prompt-golden/BehaviorTriageEngine.RULES.txt
@@ -15,8 +15,8 @@
    said — read them and see, rather than accepting that they must.
 5. **Always open the evidence, and write the code to check it.** Never rule from the summary.
    Anything mechanical — a count, a rate, a quantile, a share, a date range — gets COMPUTED
-   by a script you wrote and ran, never eyeballed. State the sample you took: which refs, how
-   many, in what order.
+   by a script you wrote and ran, never eyeballed. Compute over all the rows, not a sample.
+   Say which ones you opened.
 6. **Unsure means close.** `unclear` closes the finding, and that is the intended outcome
    whenever the evidence does not settle it. A cause that is real keeps firing and comes back
    for a second look; one that never fires again cost nobody a decision.

--- a/backend/surfaces/src/main/java/ai/tessary/mcp/McpToolRegistry.java
+++ b/backend/surfaces/src/main/java/ai/tessary/mcp/McpToolRegistry.java
@@ -728,11 +728,15 @@ public class McpToolRegistry {
 
         add(new McpTool(
                 "get_finding_evidence",
-                "Page the substrate a finding's claim rests on: one ref per row the detector measured, at the"
+                "Page the substrate a finding's claim rests on: one row per unit the detector measured, at the"
                         + " grain it measured (role 'member' is the flagged population ENUMERATED, not a sample;"
                         + " 'baseline' is the reference window's rows; 'exemplar' / 'witness' / 'changepoint' are"
-                        + " the reading aids). Refs are IDS, not bodies — follow one with get_trace, get_span"
-                        + " (both ids) or list_spans. Call it with count_only=true first: that returns the"
+                        + " the reading aids). Each row carries what was MEASURED on it, not just a pointer to"
+                        + " it: role, rank, sessionId, traceId, spanId, name, kind, status, level, errorType,"
+                        + " startedAt, latencyMs, totalTokens, totalCost, model, callSiteId. So compare, rank and"
+                        + " pick rows from the page itself, and open only the ones you decided to open — the"
+                        + " payloads are NOT here, and get_span (trace id plus span id) is where a body comes"
+                        + " from. Call it with count_only=true first: that returns the"
                         + " per-role sizes with no rows, so you can decide how much to page before you spend"
                         + " context on it. counts is what SURVIVES and can still be opened; recorded_counts is"
                         + " what the detector wrote at finding-open — counts below recorded means substrate aged"
@@ -758,10 +762,11 @@ public class McpToolRegistry {
                                         "count_only",
                                         boolField("Optional. Return the per-role counts with no rows — the cheap"
                                                 + " first call. Rows are omitted rather than empty, and"
-                                                + " rows_omitted says so.")),
+                                                + " rowsOmitted says so. This page answers under 'refs' (empty)"
+                                                + " rather than 'rows'.")),
                                 Map.entry(
                                         "limit",
-                                        intField("Optional. Max refs in this page (default " + EVIDENCE_DEFAULT_LIMIT
+                                        intField("Optional. Max rows in this page (default " + EVIDENCE_DEFAULT_LIMIT
                                                 + ", capped at " + EVIDENCE_MAX_LIMIT + ").")),
                                 Map.entry(
                                         "cursor",
@@ -822,15 +827,25 @@ public class McpToolRegistry {
     }
 
     /**
-     * {@code get_finding_evidence}: a page of the population a detector enumerated. Delegates to
-     * {@link FindingService#findingEvidence}, which carries the same reachability guard {@code get_finding}
-     * does, so the gate lives in one place rather than being restated per tool.
+     * {@code get_finding_evidence}: a page of the population a detector enumerated, each row joined to what
+     * was measured on it. Delegates to {@link FindingService#findingEvidenceSpans}, which carries the same
+     * reachability guard {@code get_finding} does, so the gate lives in one place rather than being
+     * restated per tool.
+     *
+     * <p>Measurements rather than bare refs because a reading agent judging a row cannot do it from an id:
+     * with only ids, deciding whether one row of 174 is worth opening costs a {@code get_span} per row, so
+     * it opens a handful, picks them blind, and rules on those. The numbers it selects on now ride the page
+     * it selects from.
+     *
+     * <p>{@code count_only} still goes to {@link FindingService#findingEvidence}: the cheap sizing call
+     * returns no rows, so joining to spans it would not return buys nothing, and that path has no span
+     * variant.
      *
      * <p>An unrecognised {@code role} is an error, not an empty page, same reasoning as
      * {@link #listCases}: a client can send anything regardless of the schema, and an empty page here would
      * read as "no evidence" rather than "bad argument".
      */
-    private BehaviorDtos.FindingEvidencePage getFindingEvidence(TenantContext ctx, Map<String, Object> args) {
+    private Object getFindingEvidence(TenantContext ctx, Map<String, Object> args) {
         String projectId = requireProject(ctx).id();
         String findingId = requireStr(args, "finding_id");
         String role = strArg(args, "role");
@@ -839,14 +854,77 @@ public class McpToolRegistry {
                     + FindingEvidenceRow.Role.ALL + ".");
         }
         int pageSize = TracePageCodec.clampLimit(intArg(args, "limit"), EVIDENCE_DEFAULT_LIMIT, EVIDENCE_MAX_LIMIT);
+        String cursor = strArg(args, "cursor");
         try {
-            return behaviorDrift.findingEvidence(
-                    projectId, findingId, role, pageSize, strArg(args, "cursor"), boolArg(args, "count_only"));
+            if (boolArg(args, "count_only")) {
+                return behaviorDrift.findingEvidence(projectId, findingId, role, pageSize, cursor, true);
+            }
+            BehaviorDtos.FindingEvidenceSpanPage page =
+                    behaviorDrift.findingEvidenceSpans(projectId, findingId, role, pageSize, cursor);
+            return new EvidenceSpanPage(
+                    page.rows().stream().map(EvidenceSpan::of).toList(),
+                    page.nextCursor(),
+                    page.counts(),
+                    page.recordedCounts());
         } catch (TessaryException e) {
             String message = e.getMessage();
             throw new McpTool.ToolException(message == null ? "finding not found: " + findingId : message, e);
         }
     }
+
+    /**
+     * One evidence row on the MCP door: {@link BehaviorDtos.EvidenceSpanView} without the payload previews.
+     *
+     * <p>The previews are dropped here rather than in the view, which the finding page's evidence table
+     * shares and still renders them in. This surface hands out measurements and ids; payload text comes
+     * from {@code get_span}, where a caller asks for one span's body on purpose instead of receiving a
+     * thousand truncated ones it did not ask for.
+     */
+    record EvidenceSpan(
+            String role,
+            @Nullable Integer rank,
+            @Nullable String sessionId,
+            @Nullable String traceId,
+            @Nullable String spanId,
+            @Nullable String name,
+            @Nullable String kind,
+            @Nullable String status,
+            @Nullable String level,
+            @Nullable String errorType,
+            @Nullable String startedAt,
+            @Nullable Long latencyMs,
+            @Nullable Long totalTokens,
+            @Nullable Double totalCost,
+            @Nullable String model,
+            @Nullable String callSiteId) {
+
+        static EvidenceSpan of(BehaviorDtos.EvidenceSpanView v) {
+            return new EvidenceSpan(
+                    v.role(),
+                    v.rank(),
+                    v.sessionId(),
+                    v.traceId(),
+                    v.spanId(),
+                    v.name(),
+                    v.kind(),
+                    v.status(),
+                    v.level(),
+                    v.errorType(),
+                    v.startedAt(),
+                    v.latencyMs(),
+                    v.totalTokens(),
+                    v.totalCost(),
+                    v.model(),
+                    v.callSiteId());
+        }
+    }
+
+    /** {@link BehaviorDtos.FindingEvidenceSpanPage} with {@link EvidenceSpan} rows: the same envelope. */
+    record EvidenceSpanPage(
+            List<EvidenceSpan> rows,
+            @Nullable String nextCursor,
+            Map<String, Long> counts,
+            Map<String, Long> recordedCounts) {}
 
     private void add(McpTool t) {
         tools.put(t.name(), t);

--- a/backend/surfaces/src/test/java/ai/tessary/mcp/McpFindingToolsTest.java
+++ b/backend/surfaces/src/test/java/ai/tessary/mcp/McpFindingToolsTest.java
@@ -20,8 +20,9 @@ import ai.tessary.classifier.catalog.BuiltInDetector;
 import ai.tessary.classifier.finding.BehaviorDtos.BehaviorFindingDetailView;
 import ai.tessary.classifier.finding.BehaviorDtos.BehaviorFindingView;
 import ai.tessary.classifier.finding.BehaviorDtos.BehaviorFindingsView;
-import ai.tessary.classifier.finding.BehaviorDtos.EvidenceRefView;
+import ai.tessary.classifier.finding.BehaviorDtos.EvidenceSpanView;
 import ai.tessary.classifier.finding.BehaviorDtos.FindingEvidencePage;
+import ai.tessary.classifier.finding.BehaviorDtos.FindingEvidenceSpanPage;
 import ai.tessary.classifier.finding.FindingEvidenceRow;
 import ai.tessary.classifier.finding.FindingRow;
 import ai.tessary.classifier.finding.FindingService;
@@ -360,13 +361,48 @@ class McpFindingToolsTest {
         return out;
     }
 
-    private static FindingEvidencePage samplePage(@Nullable String nextCursor) {
-        return new FindingEvidencePage(
+    private static FindingEvidenceSpanPage samplePage(@Nullable String nextCursor) {
+        return new FindingEvidenceSpanPage(
                 List.of(
-                        new EvidenceRefView("trace", null, "trace-7", null, FindingEvidenceRow.Role.MEMBER, 0),
-                        new EvidenceRefView("span", null, "trace-8", "span-2", FindingEvidenceRow.Role.MEMBER, 3)),
+                        new EvidenceSpanView(
+                                FindingEvidenceRow.Role.MEMBER,
+                                0,
+                                "sess-4",
+                                "trace-7",
+                                null,
+                                "plan",
+                                "llm",
+                                "ok",
+                                null,
+                                null,
+                                "2026-02-03T10:00:00Z",
+                                7293L,
+                                4120L,
+                                0.031,
+                                "claude-opus-5",
+                                "otto-von-bismarck",
+                                "what the span was given",
+                                "what it returned"),
+                        new EvidenceSpanView(
+                                FindingEvidenceRow.Role.MEMBER,
+                                3,
+                                "sess-9",
+                                "trace-8",
+                                "span-2",
+                                "lookup",
+                                "tool",
+                                "error",
+                                "error",
+                                "Timeout",
+                                "2026-02-03T10:04:00Z",
+                                84L,
+                                null,
+                                null,
+                                null,
+                                "otto-von-bismarck",
+                                "tool input",
+                                "tool output")),
                 nextCursor,
-                false,
                 counts(120, 0),
                 counts(120, 0));
     }
@@ -384,38 +420,67 @@ class McpFindingToolsTest {
     }
 
     /**
-     * The refs are ids at a grain, and both grains round-trip: a trace ref carries one id, a span ref
-     * carries BOTH (span identity under substrate v2 is the composite key), and {@code rank} survives with
-     * its gaps intact — it is the detector's order, not an index.
+     * A row carries what was measured on it, not just a pointer to it: the ids still round-trip (a
+     * trace-grain row carries no span id, a span-grain row carries both, since span identity under
+     * substrate v2 is the composite key), and {@code rank} survives with its gaps intact — it is the
+     * detector's order, not an index — but latency, tokens, cost and call site ride along, which is what
+     * lets a reader rank the page before it opens anything.
      */
     @Test
-    void getFindingEvidence_pagesRefsAsIdsAtTheirGrain() throws Exception {
-        when(behaviorDrift.findingEvidence(PROJECT_ID, "find-1", null, 100, null, false))
+    void getFindingEvidence_pagesRowsWithTheirMeasurements() throws Exception {
+        when(behaviorDrift.findingEvidenceSpans(PROJECT_ID, "find-1", null, 100, null))
                 .thenReturn(samplePage("cursor-2"));
 
         JsonNode body = structured(callTool("get_finding_evidence", "{\"finding_id\":\"find-1\"}"));
 
-        assertEquals(2, body.get("refs").size());
-        assertEquals("trace-7", body.get("refs").get(0).get("traceId").asText());
-        assertTrue(body.get("refs").get(0).get("spanId").isNull(), "a trace ref carries no span id");
-        assertEquals("span", body.get("refs").get(1).get("grain").asText());
-        assertEquals("trace-8", body.get("refs").get(1).get("traceId").asText());
-        assertEquals("span-2", body.get("refs").get(1).get("spanId").asText());
-        assertEquals(3, body.get("refs").get(1).get("rank").asInt());
+        assertEquals(2, body.get("rows").size());
+        JsonNode first = body.get("rows").get(0);
+        assertEquals("trace-7", first.get("traceId").asText());
+        assertTrue(first.get("spanId").isNull(), "a trace-grain row carries no span id");
+        assertEquals(7293, first.get("latencyMs").asLong());
+        assertEquals(4120, first.get("totalTokens").asLong());
+        assertEquals("claude-opus-5", first.get("model").asText());
+        assertEquals("otto-von-bismarck", first.get("callSiteId").asText());
+        JsonNode second = body.get("rows").get(1);
+        assertEquals("trace-8", second.get("traceId").asText());
+        assertEquals("span-2", second.get("spanId").asText());
+        assertEquals(3, second.get("rank").asInt());
+        assertEquals(84, second.get("latencyMs").asLong());
+        assertEquals("Timeout", second.get("errorType").asText());
+        // A tool span has neither, and an empty cell is the honest answer rather than a zero.
+        assertTrue(second.get("totalTokens").isNull(), "a tool span has no tokens");
         assertEquals("cursor-2", body.get("nextCursor").asText());
+        assertEquals(120, body.get("counts").get("member").asLong());
+    }
+
+    /**
+     * The previews stay on the table the UI renders and never reach this door. An agent that wants a
+     * body asks {@code get_span} for one span on purpose, instead of being handed a thousand truncated
+     * ones it did not ask for.
+     */
+    @Test
+    void getFindingEvidence_dropsThePayloadPreviews() throws Exception {
+        when(behaviorDrift.findingEvidenceSpans(PROJECT_ID, "find-1", null, 100, null))
+                .thenReturn(samplePage(null));
+
+        JsonNode body = structured(callTool("get_finding_evidence", "{\"finding_id\":\"find-1\"}"));
+
+        JsonNode first = body.get("rows").get(0);
+        assertFalse(first.has("inputPreview"), first.toString());
+        assertFalse(first.has("outputPreview"), first.toString());
     }
 
     /** The paging contract: default limit, the cap, the role filter and the cursor all reach the service. */
     @Test
     void getFindingEvidence_passesRoleLimitAndCursorThroughAndClampsTheLimit() throws Exception {
-        when(behaviorDrift.findingEvidence(eq(PROJECT_ID), eq("find-1"), any(), anyInt(), any(), anyBoolean()))
+        when(behaviorDrift.findingEvidenceSpans(eq(PROJECT_ID), eq("find-1"), any(), anyInt(), any()))
                 .thenReturn(samplePage(null));
 
         structured(callTool(
                 "get_finding_evidence",
                 "{\"finding_id\":\"find-1\",\"role\":\"member\",\"limit\":9000,\"cursor\":\"c-1\"}"));
 
-        verify(behaviorDrift).findingEvidence(PROJECT_ID, "find-1", FindingEvidenceRow.Role.MEMBER, 1000, "c-1", false);
+        verify(behaviorDrift).findingEvidenceSpans(PROJECT_ID, "find-1", FindingEvidenceRow.Role.MEMBER, 1000, "c-1");
     }
 
     /**
@@ -431,6 +496,8 @@ class McpFindingToolsTest {
 
         assertEquals(0, body.get("refs").size());
         assertTrue(body.get("rowsOmitted").asBoolean(), "count_only omits rows rather than returning none");
+        // The sizing call returns no rows, so there is nothing to join spans to.
+        verify(behaviorDrift, org.mockito.Mockito.never()).findingEvidenceSpans(any(), any(), any(), anyInt(), any());
         // Live below recorded is retention, not a lost write — the pair is the whole point of sending both.
         assertEquals(118, body.get("counts").get("member").asLong());
         assertEquals(120, body.get("recordedCounts").get("member").asLong());
@@ -449,6 +516,7 @@ class McpFindingToolsTest {
 
         assertTrue(text.contains("members"), text);
         assertTrue(text.contains(FindingEvidenceRow.Role.BASELINE), text);
+        verify(behaviorDrift, org.mockito.Mockito.never()).findingEvidenceSpans(any(), any(), any(), anyInt(), any());
         verify(behaviorDrift, org.mockito.Mockito.never())
                 .findingEvidence(any(), any(), any(), anyInt(), any(), anyBoolean());
     }
@@ -458,6 +526,7 @@ class McpFindingToolsTest {
         String text = errorText(callTool("get_finding_evidence", "{}"));
 
         assertTrue(text.contains("finding_id"), text);
+        verify(behaviorDrift, org.mockito.Mockito.never()).findingEvidenceSpans(any(), any(), any(), anyInt(), any());
         verify(behaviorDrift, org.mockito.Mockito.never())
                 .findingEvidence(any(), any(), any(), anyInt(), any(), anyBoolean());
     }
@@ -468,7 +537,7 @@ class McpFindingToolsTest {
      */
     @Test
     void getFindingEvidence_notFoundIsCleanToolError() throws Exception {
-        when(behaviorDrift.findingEvidence(eq(PROJECT_ID), eq("other-tenant"), any(), anyInt(), any(), anyBoolean()))
+        when(behaviorDrift.findingEvidenceSpans(eq(PROJECT_ID), eq("other-tenant"), any(), anyInt(), any()))
                 .thenThrow(new TessaryException(ClassifierError.FINDING_NOT_FOUND, "other-tenant"));
 
         String text = errorText(callTool("get_finding_evidence", "{\"finding_id\":\"other-tenant\"}"));

--- a/claude-skill/evals-mcp/README.md
+++ b/claude-skill/evals-mcp/README.md
@@ -81,11 +81,13 @@ Conventions the tools share, stated here once rather than per row:
   `list_sessions`): `limit` (default 50, capped 100) + `cursor` in, `next_cursor` out. An unreadable or
   stale cursor restarts at the newest page rather than erroring. `query_search` keeps its own older
   limits (default 100, capped 1000), and `get_finding_evidence` pages at the same wider bound — its rows
-  are ids rather than prose, and the set it pages is a whole measured population.
+  are ids and numbers rather than prose, and the set it pages is a whole measured population.
 - **Lists find, gets read.** List rows carry typed columns and the stored `input_preview`/`output_preview`
   plus `payload_available`, never the full payload. Raw text comes from `get_span`, or from `get_trace` /
   `list_spans` with `fields: ["payload"]` on a page already scoped to one trace or ≤ 24h.
-- Timestamps ISO-8601; the snake_case wire shape is identical to REST.
+- Timestamps ISO-8601; the snake_case wire shape is identical to REST. The one exception is
+  `get_finding_evidence`, whose response fields are camelCase; its arguments are snake_case like
+  every other tool's.
 
 | Tool | Args (`limit`/`cursor` omitted — see above) | Returns | Gate |
 |---|---|---|---|
@@ -96,7 +98,7 @@ Conventions the tools share, stated here once rather than per row:
 | `get_case` | `id` (stored id or `C-118`) | case + activity trail + `finding_id` + exemplars + the **RCA report inline in `rca`** when one has finished | open |
 | `list_findings` | `status`, `call_site_id`, `detector`, `include` | headline finding rows (no evidence blob) + withheld count | open |
 | `get_finding` | `id` | finding + parsed evidence | open |
-| `get_finding_evidence` | `finding_id`, `role` (exemplar\|member\|baseline\|witness\|changepoint), `count_only` | paged refs `{role, grain, session_id?, trace_id?, span_id?, rank?}` into the population the detector measured, + live and as-written per-role counts | open |
+| `get_finding_evidence` | `finding_id`, `role` (exemplar\|member\|baseline\|witness\|changepoint), `count_only` | paged `rows` into the population the detector measured, each joined to its span — `{role, rank, sessionId, traceId, spanId, name, kind, status, level, errorType, startedAt, latencyMs, totalTokens, totalCost, model, callSiteId}`, camelCase, no payload text — + live and as-written per-role counts. `count_only` answers with counts alone under `refs` | open |
 | `list_traces` | `model`, `kind`, `call_site_id`, `status`, `range`, `q` | paged trace rollup rows + previews | open |
 | `get_trace` | `trace_id`, `fields` | rollup + spans, oldest-first, capped 200 + `spans_truncated`; skeleton rows (typed columns + previews + `payload_available`) unless `fields: ["payload"]` | open |
 | `list_spans` | `trace_id`, `call_site_id`, `kind`, `name`, `status`, `model_id`, `session_id`, `range`, `q`, `mode` (keyword\|semantic), `fields` | paged compact span rows; full payloads only when scoped | open |

--- a/devdocs/reference/auth-and-mcp.md
+++ b/devdocs/reference/auth-and-mcp.md
@@ -71,9 +71,14 @@ no registered tool name is write-shaped, and none of the tools removed by the cu
 
 **`get_finding_evidence` is the door the analysis lanes read through.** A detector enumerates the
 population its claim rests on at finding-open — one `finding_evidence` ref per measured row, uncapped —
-and this tool pages those refs back out: `{role, grain, session_id?, trace_id?, span_id?, rank?}` +
-`next_cursor`, plus `count_only=true` for the per-role sizes with no rows. Refs are ids, not bodies;
-the caller follows one with `get_trace` / `get_span` / `list_spans`. That is what lets triage and RCA
+and this tool pages those rows back out joined to the span each names, so a row says what was measured
+on it rather than only where to find it: `{role, rank, sessionId, traceId, spanId, name, kind, status,
+level, errorType, startedAt, latencyMs, totalTokens, totalCost, model, callSiteId}` + `nextCursor`
+(camelCase, unlike the snake_case tools around it), plus `count_only=true` for the per-role sizes with
+no rows, which answers in the ref shape under `refs`. The join is read-time, so it holds for evidence
+already recorded. Payload text is not on the page; the caller follows a row with `get_trace` /
+`get_span` / `list_spans`. Rows carrying their own numbers is what lets a lane rank a population of
+hundreds and open the handful it chose, instead of opening a handful and calling that the population. That is what lets triage and RCA
 ship a dossier of the finding's *claim* alone and fetch the traffic on demand, rather than hydrating
 traces into a prompt — the materialize-what-is-finding-specific, read-substrate-over-MCP posture both
 lanes take. It is scoped and gated exactly like `get_finding` (same service, same project scope, a


### PR DESCRIPTION
## Why

A triage agent's only view of an individual evidence row is `get_finding_evidence`. The dossier carries the detector's summary, and `prompt-craft/triage/preflight.md` forbids ruling from that alone, so every row-level judgement flows through this one tool.

It returned identifiers only: `role`, `grain`, `sessionId`, `traceId`, `spanId`, `rank`. Nothing about what was measured. Learning how slow a single span was cost a `get_span` and a whole payload in context, so faced with 174 evidence rows an agent opened 9, chose them blind, and closed a real regression.

`FindingService` already exposed the join `FindingController` uses for the UI. This puts it on the agent's path.

## What changed

- `McpToolRegistry.getFindingEvidence` calls `findingEvidenceSpans(...)`. A row now carries `name`, `kind`, `status`, `level`, `errorType`, `startedAt`, `latencyMs`, `totalTokens`, `totalCost`, `model` and `callSiteId` beside its ids. 16 fields, under `rows`.
- `count_only=true` still calls `findingEvidence(...)`, unchanged. The sizing call returns no rows, so joining to spans it would not return buys nothing, and that path has no `countOnly` variant. It still answers under `refs` with `rowsOmitted`.
- The MCP mapping drops `inputPreview`/`outputPreview`. `BehaviorDtos$EvidenceSpanView` is shared with `FindingController`, and the UI keeps rendering them.
- Prompts: rule 5 and both `mcp_door.md` files described the old shape and licensed a sample. They now say compute over all the rows, page the whole role, and state which rows you opened.
- Reference docs updated to match: `devdocs/reference/auth-and-mcp.md`, `claude-skill/evals-mcp/README.md`.

## Unchanged

Tool inputs (still snake_case in, camelCase out), limits (100 / 1000), paging, counts, the REST path, the UI response shape, and the `finding_evidence` table. The join is read-time, so this works on evidence already recorded. No `payloadAvailable` field.

## For the reviewer

- **Page key changed** from `refs` to `rows` on the non-count path. `count_only` keeps `refs`. That asymmetry is deliberate: the two are different shapes now.
- **Prompt goldens.** `PromptResourceParityTest` pins every `prompt-craft/` file byte for byte. I recaptured the three affected goldens by copying each markdown over its golden, not with `-Dprompt.golden.capture=true`, which rewrites all nine and would hide unrelated drift.
- **Tests modified, not added.** Six cases in `McpFindingToolsTest` pinned the old shape.
- **Dead branch left in place.** `FindingService.findingEvidence`'s non-`countOnly` path now has no production caller. Left alone, since `count_only` still routes there. Worth a follow-up.

## Verification

- `scripts/check.sh prompt,classifier,rca,mcp` exits 0.
- Full gate is green except `KafkaSpoolIntegrationTest`, which fails identically on `b8e2f2e` with no changes applied. Cause is in its output: `KAFKA_STORAGE_ERROR: Disk error when trying to access log file`, a Redpanda testcontainer degrading on a Docker VM at 3.9 GB free of 15.6 GB. Pre-existing and environmental.
- Against the live database for finding `01M239N7P8Y6HGVXF202R0X4WR`, role `baseline`: 100 rows, rank 0 at 7293 ms, rank 1 at 84 ms, both `otto-von-bismarck`. All 174 evidence rows resolve a span with a latency.
- One correction to the brief's expected output: with `limit=200` there is no `nextCursor`, because baseline holds exactly 100 live rows. A cursor appears only below limit 100.
- No live MCP call. The local stack runs the released `backend-1.0.1` image rather than this branch, so the tool itself is covered by unit tests and the join by the query above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)